### PR TITLE
Remove unused WebGpuRenderer stub

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -105,6 +105,9 @@ GLOBAL_LOGS: Vec<String>     // Debug логи
 ## 📦 Сборка
 
 ```bash
+# Установите wasm32 таргет один раз
+rustup target add wasm32-unknown-unknown
+
 # Development
 cargo build --target wasm32-unknown-unknown
 

--- a/src/infrastructure/rendering/mod.rs
+++ b/src/infrastructure/rendering/mod.rs
@@ -1,8 +1,6 @@
 pub mod webgpu_renderer;
 pub mod gpu_structures;
-pub mod webgpu;
 
 // Re-exports for convenient access - WebGPU only! 🚀
-pub use webgpu::*;
 pub use webgpu_renderer::WebGpuRenderer;
-pub use gpu_structures::*; 
+pub use gpu_structures::*;

--- a/src/infrastructure/rendering/webgpu.rs
+++ b/src/infrastructure/rendering/webgpu.rs
@@ -1,8 +1,0 @@
-// WebGPU rendering infrastructure - заглушка
-pub struct WebGpuRenderer;
-
-impl WebGpuRenderer {
-    pub fn new() -> Self {
-        Self
-    }
-} 


### PR DESCRIPTION
## Summary
- remove the obsolete `webgpu.rs` stub
- tidy rendering module exports
- document `rustup target add wasm32-unknown-unknown`

## Testing
- `cargo check --target wasm32-unknown-unknown`


------
https://chatgpt.com/codex/tasks/task_e_6846dbb99064833185e63085cbaa38fe