### PR TITLE
Fix build workflow permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,11 +4,15 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions: write-all
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: stable


### PR DESCRIPTION
## Summary
- allow GitHub Actions to push updates
- push using the repo token

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68473c74c684833196f2d50787e21b01