### PR TITLE
Fix relative paths in docs index

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -36,7 +36,7 @@
             100% { transform: rotate(360deg); }
         }
     </style>
-<link rel="modulepreload" href="/price-chart-wasm-88c21f3841d4e185.js" crossorigin="anonymous" integrity="sha384-YNloKmKHCm/C2N+QVERlZQ0dfVsYwTcVPySfuxMyW0lzAFCX6w1sR+Dg1ieJvbUY"><link rel="preload" href="/price-chart-wasm-88c21f3841d4e185_bg.wasm" crossorigin="anonymous" integrity="sha384-P5fTs9PCNzkLvCTcp+ArprVjmPVX9x6nv9FHpc5rj/m3+mpP/xc6DKuKfgLsSpBG" as="fetch" type="application/wasm"></head>
+<link rel="modulepreload" href="./price-chart-wasm-88c21f3841d4e185.js" crossorigin="anonymous" integrity="sha384-YNloKmKHCm/C2N+QVERlZQ0dfVsYwTcVPySfuxMyW0lzAFCX6w1sR+Dg1ieJvbUY"><link rel="preload" href="./price-chart-wasm-88c21f3841d4e185_bg.wasm" crossorigin="anonymous" integrity="sha384-P5fTs9PCNzkLvCTcp+ArprVjmPVX9x6nv9FHpc5rj/m3+mpP/xc6DKuKfgLsSpBG" as="fetch" type="application/wasm"></head>
 <body>
     <!-- Loading screen -->
     <div id="loading">
@@ -50,8 +50,8 @@
     <!-- Trunk автоматически подключит WASM здесь -->
     
 <script type="module">
-import init, * as bindings from '/price-chart-wasm-88c21f3841d4e185.js';
-const wasm = await init({ module_or_path: '/price-chart-wasm-88c21f3841d4e185_bg.wasm' });
+import init, * as bindings from './price-chart-wasm-88c21f3841d4e185.js';
+const wasm = await init({ module_or_path: './price-chart-wasm-88c21f3841d4e185_bg.wasm' });
 
 
 window.wasmBindings = bindings;


### PR DESCRIPTION
## Summary
- use relative links for wasm assets in `docs/index.html`

## Testing
- `git diff --unified=3 docs/index.html`

------
https://chatgpt.com/codex/tasks/task_e_6847e513de0483319a3d2bb1caf11345