### PR TITLE
Add capacity method to CandleSeries

### DIFF
--- a/src/domain/chart/entities.rs
+++ b/src/domain/chart/entities.rs
@@ -32,7 +32,7 @@ impl Chart {
         candles.sort_by(|a, b| a.timestamp.value().cmp(&b.timestamp.value()));
         
         // Создаем новую серию с исходным лимитом
-        let limit = self.data.max_size();
+        let limit = self.data.capacity();
         self.data = CandleSeries::new(limit);
         
         // Добавляем исторические свечи (уже отсортированные)

--- a/src/domain/market_data/entities.rs
+++ b/src/domain/market_data/entities.rs
@@ -114,6 +114,11 @@ impl CandleSeries {
         self.max_size
     }
 
+    /// Ёмкость серии (максимальное количество свечей)
+    pub fn capacity(&self) -> usize {
+        self.max_size
+    }
+
     /// Получить последнюю цену закрытия
     pub fn get_latest_price(&self) -> Option<&Price> {
         self.candles.back().map(|candle| &candle.ohlcv.close)


### PR DESCRIPTION
## Summary
- expose CandleSeries::capacity
- use new capacity method when resetting historical data

## Testing
- `cargo test` *(fails: couldn't finish due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_6847e4ef04a08331bfdfb0d35fd17baf