### PR TITLE
Добавлены метрики FPS и глобальный рендерер

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ wgpu = "25.0.2"
 wasm-bindgen = "0.2.92"
 wasm-bindgen-futures = "0.4"
 js-sys = "0.3.69"
-web-sys = { version = "0.3.69", features = ["HtmlCanvasElement", "Window", "Document", "Navigator", "console"] }
+web-sys = { version = "0.3.69", features = ["HtmlCanvasElement", "Window", "Document", "Navigator", "console", "Performance"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytemuck = { version = "1.14.0", features = ["derive"] }

--- a/src/app.rs
+++ b/src/app.rs
@@ -14,7 +14,10 @@ use crate::{
         logging::{LogComponent, LogLevel, get_logger},
         market_data::{Candle, TimeInterval, value_objects::Symbol},
     },
-    infrastructure::{rendering::WebGpuRenderer, websocket::BinanceWebSocketClient},
+    infrastructure::{
+        rendering::{WebGpuRenderer, renderer::set_global_renderer},
+        websocket::BinanceWebSocketClient,
+    },
 };
 
 // 🔗 Глобальные сигналы для логов (bridge к domain::logging)
@@ -561,7 +564,8 @@ fn ChartContainer() -> impl IntoView {
                         );
 
                         let renderer_rc = Rc::new(RefCell::new(webgpu_renderer));
-                        set_renderer.set(Some(renderer_rc));
+                        set_renderer.set(Some(renderer_rc.clone()));
+                        set_global_renderer(renderer_rc.clone());
                         set_status.set("✅ WebGPU renderer ready".to_string());
 
                         // Запускаем WebSocket после инициализации renderer

--- a/src/infrastructure/rendering/renderer/initialization.rs
+++ b/src/infrastructure/rendering/renderer/initialization.rs
@@ -220,6 +220,8 @@ impl WebGpuRenderer {
             cached_zoom_level: 1.0,
             zoom_level: 1.0,
             pan_offset: 0.0,
+            last_frame_time: 0.0,
+            fps_samples: Vec::new(),
         })
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,8 +48,10 @@ pub async fn is_webgpu_supported() -> bool {
 #[cfg(target_arch = "wasm32")]
 #[wasm_bindgen]
 pub fn get_renderer_performance() -> String {
-    // Заглушка - возвращаем статическую информацию
-    "{\"backend\":\"WebGPU\",\"status\":\"ready\",\"fps\":60}".to_string()
+    crate::infrastructure::rendering::renderer::with_global_renderer(|r| {
+        r.get_performance_info()
+    })
+    .unwrap_or_else(|| "{\"backend\":\"WebGPU\",\"status\":\"not_ready\"}".to_string())
 }
 
 // Clean WASM exports only


### PR DESCRIPTION
## Summary
- хранение времени кадра и сбор FPS в `WebGpuRenderer`
- средний FPS в `get_performance_info`
- глобальный доступ к рендереру для JS
- обновлены зависимости `web-sys`

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_6847f4bab144833198ec2bd5e137cee0