### PR TITLE
Fix artifact action version

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Analyze FPS
         run: |
           python scripts/compare_fps.py benchmark_result.json docs/perf_baseline.json docs/perf_result.json 5
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: perf_results
           path: docs/perf_result.json

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Run benchmarks
         run: wasm-pack test --headless --chrome -- --nocapture | tee perf.log
       - name: Upload results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: perf-log
           path: perf.log


### PR DESCRIPTION
## Summary
- update workflow to use `actions/upload-artifact@v4`

## Testing
- `cargo test` *(fails: could not execute wasm test binary)*
- `cargo fmt -- --check` *(fails: rustfmt not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6847fac604908331ad631d68a146d208