### PR TITLE
обновлены пути сборки

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,12 +20,12 @@ jobs:
       - name: Install trunk
         run: cargo install trunk
       - name: Build
-        run: trunk build --release --dist docs
-      - name: Commit docs
+        run: trunk build --release --dist dist
+      - name: Commit dist
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git add docs
-          git commit -m "Update docs" || echo "No changes"
+          git add dist
+          git commit -m "Update dist" || echo "No changes"
           git push
 

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ ehthumbs.db
 
 # Leptos artifacts
 /dist
+/dist-local
 /public
 
 # Test and benchmark results

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 COPY . .
 
 # Сборка проекта через Trunk
-RUN trunk build --release
+RUN trunk build --release --dist dist
 
 FROM nginx:alpine
 WORKDIR /usr/share/nginx/html

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Trunk compiles the project and automatically injects the generated WASM into `in
 
 ```bash
 trunk serve       # dev server on http://localhost:8080
-# or
-trunk build       # build to ./dist
+# или
+trunk build --dist dist-local
 ```
 
 When using Trunk, open **`index.html`** (served automatically when using `trunk serve`). The file contains a Trunk hook so the WASM is loaded for you:

--- a/Trunk.toml
+++ b/Trunk.toml
@@ -1,4 +1,4 @@
 [build]
 filehash = false
-dist = "docs"
+dist = "dist-local"
 public_url = "/webgpu-candles/"


### PR DESCRIPTION
## Изменения
- изменён выходной каталог по умолчанию в `Trunk.toml`
- добавлен `dist-local/` в `.gitignore`
- обновлена инструкция сборки в `README.md`
- CI и Docker теперь явно используют `--dist dist`

## Тесты
- `cargo check --tests --benches`


------
https://chatgpt.com/codex/tasks/task_e_684829e03dd883319cd7fa9c3c2a5ff4