### PR TITLE
Fix candle positioning

### DIFF
--- a/src/infrastructure/rendering/renderer/geometry.rs
+++ b/src/infrastructure/rendering/renderer/geometry.rs
@@ -4,11 +4,10 @@ use crate::log_info;
 /// Базовое количество ячеек сетки
 pub const BASE_CANDLES: f32 = 300.0;
 
-/// Вычислить позицию свечи/бара с учётом смещения
+/// Позиция свечи/бара с учётом привязки к правому краю
 pub fn candle_x_position(index: usize, visible_len: usize) -> f32 {
-    let step_size = 2.0 / BASE_CANDLES;
-    let offset = (BASE_CANDLES - visible_len as f32) * step_size;
-    -1.0 + offset + (index as f32 + 0.5) * step_size
+    let step_size = 2.0 / visible_len as f32;
+    1.0 - (visible_len as f32 - index as f32 - 0.5) * step_size
 }
 
 impl WebGpuRenderer {
@@ -97,7 +96,7 @@ impl WebGpuRenderer {
 
         // Create vertices for each visible candle
         let zoom_factor = self.zoom_level.clamp(0.1, 10.0) as f32;
-        let step_size = 2.0 / BASE_CANDLES;
+        let step_size = 2.0 / visible_candles.len() as f32;
         let candle_width = (step_size * zoom_factor * 0.8).clamp(0.002, 0.1);
 
         for (i, candle) in visible_candles.iter().enumerate() {
@@ -434,7 +433,7 @@ impl WebGpuRenderer {
         let volume_bottom = -1.0;
         let volume_height = volume_top - volume_bottom;
 
-        let step_size = 2.0 / BASE_CANDLES;
+        let step_size = 2.0 / candle_count as f32;
         let zoom_factor = self.zoom_level.clamp(0.1, 10.0) as f32;
         let bar_width = (step_size * zoom_factor * 0.8).max(0.002);
         let pan_factor = (self.pan_offset * 0.001) as f32;

--- a/tests/offset.rs
+++ b/tests/offset.rs
@@ -1,15 +1,14 @@
-use price_chart_wasm::infrastructure::rendering::renderer::{BASE_CANDLES, candle_x_position};
+use price_chart_wasm::infrastructure::rendering::renderer::candle_x_position;
 
 #[test]
 fn candle_offset_calculation() {
     let visible = 10usize;
-    let step = 2.0 / BASE_CANDLES;
-    let expected_first = -1.0 + (BASE_CANDLES - visible as f32) * step + 0.5 * step;
+    let step = 2.0 / visible as f32;
+    let expected_first = 1.0 - (visible as f32 - 0.5) * step;
     let x = candle_x_position(0, visible);
     assert!((x - expected_first).abs() < f32::EPSILON);
 
-    let expected_last =
-        -1.0 + (BASE_CANDLES - visible as f32) * step + (visible as f32 - 0.5) * step;
+    let expected_last = 1.0 - 0.5 * step;
     let x_last = candle_x_position(visible - 1, visible);
     assert!((x_last - expected_last).abs() < f32::EPSILON);
 }


### PR DESCRIPTION
## Summary
- скорректировано вычисление координат свечей и столбиков объёма
- обновлён тест `offset`

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_68483ea97e8c8331bce9fd5a11e5961b