### PR TITLE
Add zoom round-trip test

### DIFF
--- a/tests/viewport.rs
+++ b/tests/viewport.rs
@@ -46,3 +46,21 @@ fn time_to_x_calculates() {
     let x = vp.time_to_x(50.0);
     assert!((x - 100.0).abs() < 1e-6);
 }
+
+#[wasm_bindgen_test]
+fn zoom_round_trip_preserves_viewport() {
+    let mut vp = Viewport {
+        start_time: 0.0,
+        end_time: 100.0,
+        min_price: 0.0,
+        max_price: 100.0,
+        width: 800,
+        height: 600,
+    };
+    let original = vp.clone();
+    vp.zoom(2.0, 0.5);
+    vp.zoom(0.5, 0.5);
+    assert!((vp.start_time - original.start_time).abs() < 1e-6);
+    assert!((vp.end_time - original.end_time).abs() < 1e-6);
+}
+


### PR DESCRIPTION
## Summary
- check that viewport zoom is stable after zoom round-trip

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_68486353c99c8331aa0838f80c4b8a12