### PR TITLE
fix build path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git add dist
+          git add -f dist
           git commit -m "Update dist" || echo "No changes"
           git push
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ trunk serve       # dev server on http://localhost:8080
 trunk build --dist dist-local
 ```
 
+Локальные сборки сохраняются в каталог `dist-local`. В CI GitHub Actions
+используется путь `dist`, после чего файлы копируются в [`docs/`](docs/) для
+публикации демо-версии.
+
 When using Trunk, open **`index.html`** (served automatically when using `trunk serve`). The file contains a Trunk hook so the WASM is loaded for you:
 
 ```html


### PR DESCRIPTION
## Summary
- force add `dist` folder in CI workflow
- clarify `dist-local` vs `dist` usage in README

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_68486885d1c48331bd4d8e2117d9ec74