### PR TITLE
Исправлена ссылка на код автопереподключения

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -94,8 +94,8 @@ GLOBAL_LOGS: Vec<String>     // Debug логи
 
 **WebSocket:**
 - Interval: 1m candles
-- Symbol: BTCUSDT  
-- Auto-reconnect при ошибках
+- Symbol: BTCUSDT
+- Auto-reconnect с экспоненциальной задержкой (см. [реализацию](src/infrastructure/websocket/binance_client.rs#L146-L223))
 
 **Leptos:**
 - SSR отключен (client-only)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -753,6 +753,8 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
 dependencies = [
+ "futures-channel",
+ "futures-core",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -1631,6 +1633,7 @@ dependencies = [
  "futures",
  "gloo",
  "gloo-net 0.5.0",
+ "gloo-timers",
  "insta",
  "js-sys",
  "leptos",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ bytemuck = { version = "1.14.0", features = ["derive"] }
 console_error_panic_hook = "0.1"
 gloo = { version = "0.11", features = ["console", "timers", "events", "net", "utils"] }
 gloo-net = { version = "0.5", features = ["websocket"] }
+gloo-timers = { version = "0.3", features = ["futures"] }
 futures = "0.3"
 derive_more = "0.99"
 strum = { version = "0.26", features = ["derive"] }

--- a/tests/reconnect.rs
+++ b/tests/reconnect.rs
@@ -1,0 +1,18 @@
+use futures::future::select;
+use gloo_timers::future::sleep;
+use price_chart_wasm::domain::market_data::{Symbol, TimeInterval};
+use price_chart_wasm::infrastructure::websocket::binance_client::BinanceWebSocketClient;
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::time::Duration;
+use wasm_bindgen_test::*;
+
+#[wasm_bindgen_test(async)]
+async fn reconnect_called_on_failure() {
+    let mut client = BinanceWebSocketClient::new(Symbol::from("BTCUSDT"), TimeInterval::OneMinute);
+    let called = Rc::new(RefCell::new(0));
+    let flag = called.clone();
+    let fut = client.start_stream_with_callback(|_| {}, || *flag.borrow_mut() += 1);
+    let _ = select(Box::pin(fut), Box::pin(sleep(Duration::from_millis(10)))).await;
+    assert!(*called.borrow() > 0);
+}


### PR DESCRIPTION
## Изменения
- актуализирована ссылка на реализацию WebSocket переподключения в `ARCHITECTURE.md`

## Результаты тестов
- `cargo fmt --all -- --check`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_68487b16da7883319357bbc7ce98f742