### PR TITLE
Add manual timeframe selection

### DIFF
--- a/src/domain/chart/entities.rs
+++ b/src/domain/chart/entities.rs
@@ -19,7 +19,11 @@ impl Chart {
         series.insert(TimeInterval::OneMinute, CandleSeries::new(max_candles));
         series.insert(TimeInterval::FiveMinutes, CandleSeries::new(max_candles));
         series.insert(TimeInterval::FifteenMinutes, CandleSeries::new(max_candles));
+        series.insert(TimeInterval::ThirtyMinutes, CandleSeries::new(max_candles));
         series.insert(TimeInterval::OneHour, CandleSeries::new(max_candles));
+        series.insert(TimeInterval::OneDay, CandleSeries::new(max_candles));
+        series.insert(TimeInterval::OneWeek, CandleSeries::new(max_candles));
+        series.insert(TimeInterval::OneMonth, CandleSeries::new(max_candles));
 
         Self { id, chart_type, series, viewport: Viewport::default(), indicators: Vec::new() }
     }
@@ -141,8 +145,15 @@ impl Chart {
     }
 
     fn update_aggregates(&mut self, candle: Candle) {
-        let intervals =
-            [TimeInterval::FiveMinutes, TimeInterval::FifteenMinutes, TimeInterval::OneHour];
+        let intervals = [
+            TimeInterval::FiveMinutes,
+            TimeInterval::FifteenMinutes,
+            TimeInterval::ThirtyMinutes,
+            TimeInterval::OneHour,
+            TimeInterval::OneDay,
+            TimeInterval::OneWeek,
+            TimeInterval::OneMonth,
+        ];
 
         for interval in intervals.iter() {
             if let Some(series) = self.series.get_mut(interval) {

--- a/src/domain/market_data/value_objects.rs
+++ b/src/domain/market_data/value_objects.rs
@@ -147,6 +147,9 @@ impl From<&str> for Symbol {
     Deserialize,
 )]
 pub enum TimeInterval {
+    #[strum(serialize = "30m")]
+    #[serde(rename = "30m")]
+    ThirtyMinutes,
     #[strum(serialize = "1m")]
     #[serde(rename = "1m")]
     OneMinute,
@@ -170,6 +173,14 @@ pub enum TimeInterval {
     #[strum(serialize = "1d")]
     #[serde(rename = "1d")]
     OneDay,
+
+    #[strum(serialize = "1w")]
+    #[serde(rename = "1w")]
+    OneWeek,
+
+    #[strum(serialize = "1M")]
+    #[serde(rename = "1M")]
+    OneMonth,
 }
 
 impl TimeInterval {
@@ -182,9 +193,12 @@ impl TimeInterval {
             Self::OneMinute => 60 * 1000,
             Self::FiveMinutes => 5 * 60 * 1000,
             Self::FifteenMinutes => 15 * 60 * 1000,
+            Self::ThirtyMinutes => 30 * 60 * 1000,
             Self::OneHour => 60 * 60 * 1000,
             Self::FourHours => 4 * 60 * 60 * 1000,
             Self::OneDay => 24 * 60 * 60 * 1000,
+            Self::OneWeek => 7 * 24 * 60 * 60 * 1000,
+            Self::OneMonth => 30 * 24 * 60 * 60 * 1000,
         }
     }
 }

--- a/src/infrastructure/rendering/renderer/geometry.rs
+++ b/src/infrastructure/rendering/renderer/geometry.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::domain::logging::{LogComponent, get_logger};
+use leptos::SignalGetUntracked;
 
 /// Базовое количество ячеек сетки
 pub const BASE_CANDLES: f32 = 300.0;
@@ -44,9 +45,14 @@ pub fn candle_x_position(index: usize, visible_len: usize) -> f32 {
 
 impl WebGpuRenderer {
     pub(super) fn create_geometry(&self, chart: &Chart) -> (Vec<CandleVertex>, ChartUniforms) {
-        let candles = chart.get_series_for_zoom(self.zoom_level).get_candles();
-        if candles.is_empty() {
+        use crate::app::CURRENT_INTERVAL;
 
+        let interval = CURRENT_INTERVAL.with(|i| i.get_untracked());
+        let candles = chart
+            .get_series(interval)
+            .map(|s| s.get_candles())
+            .unwrap_or_else(|| chart.get_series_for_zoom(self.zoom_level).get_candles());
+        if candles.is_empty() {
             get_logger()
                 .error(LogComponent::Infrastructure("WebGpuRenderer"), "⚠️ No candles to render");
 

--- a/src/infrastructure/rendering/renderer/initialization.rs
+++ b/src/infrastructure/rendering/renderer/initialization.rs
@@ -1,4 +1,5 @@
 use super::*;
+use leptos::SignalGetUntracked;
 
 impl WebGpuRenderer {
     pub async fn is_webgpu_supported() -> bool {
@@ -236,7 +237,12 @@ impl WebGpuRenderer {
 
     pub fn update(&mut self, chart: &Chart) {
         // Simplified update method - just store vertex count for debugging
-        let candles = chart.get_series_for_zoom(self.zoom_level).get_candles();
+        use crate::app::CURRENT_INTERVAL;
+        let interval = CURRENT_INTERVAL.with(|i| i.get_untracked());
+        let candles = chart
+            .get_series(interval)
+            .map(|s| s.get_candles())
+            .unwrap_or_else(|| chart.get_series_for_zoom(self.zoom_level).get_candles());
         self.instance_count = candles.len() as u32;
 
         get_logger().info(

--- a/src/infrastructure/rendering/renderer/render_loop.rs
+++ b/src/infrastructure/rendering/renderer/render_loop.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::log_info;
+use leptos::SignalGetUntracked;
 use serde_json;
 
 impl WebGpuRenderer {
@@ -22,7 +23,12 @@ impl WebGpuRenderer {
             }
         }
 
-        let candle_count = chart.get_series_for_zoom(self.zoom_level).get_candles().len();
+        use crate::app::CURRENT_INTERVAL;
+        let interval = CURRENT_INTERVAL.with(|i| i.get_untracked());
+        let candle_count = chart
+            .get_series(interval)
+            .map(|s| s.get_candles().len())
+            .unwrap_or_else(|| chart.get_series_for_zoom(self.zoom_level).get_candles().len());
 
         // Логируем только каждые 100 кадров для производительности
         if candle_count % 100 == 0 {

--- a/tests/aggregator.rs
+++ b/tests/aggregator.rs
@@ -46,3 +46,18 @@ fn aggregates_fifteen_minutes() {
     assert!((aggregated.ohlcv.low.value() - 95.0).abs() < f64::EPSILON);
     assert!((aggregated.ohlcv.volume.value() - 15.0).abs() < f64::EPSILON);
 }
+
+#[wasm_bindgen_test]
+fn aggregates_thirty_minutes() {
+    let candles: Vec<Candle> =
+        (0..30).map(|i| minute_candle(i * 60_000, 100.0 + i as f64)).collect();
+
+    let aggregated = Aggregator::aggregate(&candles, TimeInterval::ThirtyMinutes).unwrap();
+
+    assert_eq!(aggregated.timestamp.value(), 0);
+    assert!((aggregated.ohlcv.open.value() - 100.0).abs() < f64::EPSILON);
+    assert!((aggregated.ohlcv.close.value() - 130.0).abs() < f64::EPSILON);
+    assert!((aggregated.ohlcv.high.value() - 134.0).abs() < f64::EPSILON);
+    assert!((aggregated.ohlcv.low.value() - 95.0).abs() < f64::EPSILON);
+    assert!((aggregated.ohlcv.volume.value() - 30.0).abs() < f64::EPSILON);
+}

--- a/tests/width_sync_test.rs
+++ b/tests/width_sync_test.rs
@@ -25,16 +25,8 @@ fn width_calculation_sync() {
     );
 
     // Проверяем что ширина находится в допустимых пределах
-    assert!(
-        candle_width >= MIN_ELEMENT_WIDTH,
-        "Ширина слишком мала: {:.6}",
-        candle_width
-    );
-    assert!(
-        candle_width <= MAX_ELEMENT_WIDTH,
-        "Ширина слишком велика: {:.6}",
-        candle_width
-    );
+    assert!(candle_width >= MIN_ELEMENT_WIDTH, "Ширина слишком мала: {:.6}", candle_width);
+    assert!(candle_width <= MAX_ELEMENT_WIDTH, "Ширина слишком велика: {:.6}", candle_width);
 }
 
 #[wasm_bindgen_test]


### PR DESCRIPTION
## Summary
- allow switching timeframes via `TimeframeSelector`
- expose global `CURRENT_INTERVAL`
- support more `TimeInterval` variants
- aggregate candles for new intervals
- update renderer to respect selected interval
- add test for 30 minute aggregation

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684a8a0bb7548331b30180bdc0b14ac2