### PR TITLE
fix panning

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -572,6 +572,10 @@ fn ChartContainer() -> impl IntoView {
                                 ZOOM_LEVEL.with(|z| z.with_untracked(|val| *val)) * 0.001;
                             offset.update(|o| *o += delta_x * pan_sensitivity);
                         });
+                        chart_signal.update(|ch| {
+                            let factor_x = -(delta_x as f32) / ch.viewport.width as f32;
+                            ch.pan(factor_x, 0.0);
+                        });
                         last_x.set(mouse_x);
                     });
 

--- a/tests/chart_pan.rs
+++ b/tests/chart_pan.rs
@@ -1,0 +1,25 @@
+use price_chart_wasm::domain::chart::Chart;
+use price_chart_wasm::domain::chart::value_objects::ChartType;
+use price_chart_wasm::domain::chart::value_objects::Viewport;
+use wasm_bindgen_test::*;
+
+#[wasm_bindgen_test]
+fn horizontal_pan_moves_viewport() {
+    let mut chart = Chart {
+        id: "test".to_string(),
+        chart_type: ChartType::Candlestick,
+        series: Default::default(),
+        viewport: Viewport {
+            start_time: 0.0,
+            end_time: 100.0,
+            min_price: 0.0,
+            max_price: 100.0,
+            width: 800,
+            height: 600,
+        },
+        indicators: Vec::new(),
+    };
+    chart.pan(0.1, 0.0);
+    assert!((chart.viewport.start_time - 10.0).abs() < 1e-6);
+    assert!((chart.viewport.end_time - 110.0).abs() < 1e-6);
+}


### PR DESCRIPTION
## Summary
- enable horizontal panning by updating chart viewport when dragging
- add test for horizontal pan behaviour

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684a8cb211fc83318d38f64d0793ac0b