### PR TITLE
Fix price axis zoom rendering

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -340,6 +340,18 @@ fn PriceAxisLeft(chart: RwSignal<Chart>) -> impl IntoView {
             let factor = if e.delta_y() < 0.0 { 1.1 } else { 0.9 };
             let center = e.offset_y() as f32 / 500.0;
             chart_signal.update(|c| c.zoom_price(factor as f32, center));
+
+            chart_signal.with_untracked(|ch| {
+                if ch.get_candle_count() > 0 {
+                    with_global_renderer(|r| {
+                        r.set_zoom_params(
+                            ZOOM_LEVEL.with(|z| z.with_untracked(|val| *val)),
+                            PAN_OFFSET.with(|p| p.with_untracked(|val| *val)),
+                        );
+                        let _ = r.render(ch);
+                    });
+                }
+            });
         }
     };
 

--- a/src/infrastructure/rendering/renderer/initialization.rs
+++ b/src/infrastructure/rendering/renderer/initialization.rs
@@ -249,5 +249,7 @@ impl WebGpuRenderer {
     pub fn set_zoom_params(&mut self, zoom_level: f64, pan_offset: f64) {
         self.zoom_level = zoom_level;
         self.pan_offset = pan_offset;
+        // Force geometry refresh on next render
+        self.cached_zoom_level = f64::MAX;
     }
 }

--- a/tests/width_sync_test.rs
+++ b/tests/width_sync_test.rs
@@ -25,16 +25,8 @@ fn width_calculation_sync() {
     );
 
     // Проверяем что ширина находится в допустимых пределах
-    assert!(
-        candle_width >= MIN_ELEMENT_WIDTH,
-        "Ширина слишком мала: {:.6}",
-        candle_width
-    );
-    assert!(
-        candle_width <= MAX_ELEMENT_WIDTH,
-        "Ширина слишком велика: {:.6}",
-        candle_width
-    );
+    assert!(candle_width >= MIN_ELEMENT_WIDTH, "Ширина слишком мала: {:.6}", candle_width);
+    assert!(candle_width <= MAX_ELEMENT_WIDTH, "Ширина слишком велика: {:.6}", candle_width);
 }
 
 #[wasm_bindgen_test]


### PR DESCRIPTION
## Summary
- ensure PriceAxisLeft wheel zoom re-renders the chart
- force geometry refresh when setting zoom params
- clippy formatting

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684a8a862fe08331a472fa92c8e584b5