### PR TITLE
Add deploy monitor workflow

### DIFF
--- a/.github/workflows/deploy-monitor.yml
+++ b/.github/workflows/deploy-monitor.yml
@@ -1,0 +1,30 @@
+name: deploy-monitor
+on:
+  workflow_run:
+    workflows: ["build"]
+    types:
+      - completed
+
+jobs:
+  monitor:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check version
+        env:
+          BOT_TOKEN: ${{ secrets.TELEGRAM_TOKEN }}
+          CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        run: |
+          for i in {1..6}; do
+            version=$(curl -fsSL https://example.com/version)
+            if [ "$version" = "${{ github.event.workflow_run.head_sha }}" ]; then
+              curl -s -X POST "https://api.telegram.org/bot${BOT_TOKEN}/sendMessage" \
+                -d "chat_id=${CHAT_ID}" \
+                -d "text=Deployment succeeded: $version"
+              exit 0
+            fi
+            sleep 300
+          done
+          echo "Version not updated"
+          exit 1
+

--- a/README.md
+++ b/README.md
@@ -93,6 +93,11 @@ wasm-pack test
 
 See [TESTS.md](TESTS.md) for more details about the test suite.
 
+## Deployment monitor
+
+The monitor workflow (`deploy-monitor.yml`) waits for the `build` workflow to finish. If the deployed version matches the last commit SHA, it sends a Telegram message. Add `TELEGRAM_TOKEN` and `TELEGRAM_CHAT_ID` as repository secrets for notifications.
+
+
 ## Docker
 
 Build and run the container with:


### PR DESCRIPTION
## Summary
- add workflow to check new version after build and notify Telegram
- document the workflow and required secrets

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`

------
https://chatgpt.com/codex/tasks/task_e_684a875a46408331b58110dc5e98f324