### PR TITLE
Use build script to check wasm target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "price-chart-wasm"
 version = "0.1.0"
 edition = "2024"
+build = "build.rs"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # WebGPU Candles
 
 A demonstration Bitcoin candlestick chart built with **WebGPU** for rendering and **Leptos** for the reactive UI. Real-time price data is streamed from Binance via WebSocket and drawn directly to a `<canvas>` using Rust compiled to WebAssembly.
+The project requires the `wasm32-unknown-unknown` target, which the build script verifies is installed. Install it with:
+`rustup target add wasm32-unknown-unknown`.
 
 ## Setup
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,14 @@
+use std::process::Command;
+
+fn main() {
+    let output = Command::new("rustup")
+        .args(["target", "list", "--installed"])
+        .output()
+        .expect("failed to execute rustup");
+    let installed = String::from_utf8_lossy(&output.stdout);
+    if !installed.lines().any(|l| l.trim() == "wasm32-unknown-unknown") {
+        panic!(
+            "wasm32-unknown-unknown target not installed; run `rustup target add wasm32-unknown-unknown`"
+        );
+    }
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -49,6 +49,10 @@ Regression tests:
 
 ## Running Tests
 
+Before running the suite ensure the WebAssembly target is installed:
+`rustup target add wasm32-unknown-unknown`
+
+The build script will fail if the target is missing.
 ```bash
 # All WASM tests
 wasm-pack test --node


### PR DESCRIPTION
## Summary
- verify `wasm32-unknown-unknown` target via `build.rs`
- remove helper test script
- update docs with new check

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`
- `git merge origin/main` *(fails: not something we can merge)*

------
https://chatgpt.com/codex/tasks/task_e_684a8f5366148331850abe21bdeca186