### PR TITLE
Implement version endpoint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,8 @@ jobs:
         run: cargo install trunk
       - name: Build
         run: trunk build --release --dist dist
+      - name: Record version
+        run: echo $GITHUB_SHA > dist/version
       - name: Commit dist
         run: |
           git config user.name github-actions

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ WORKDIR /app
 COPY . .
 
 # Сборка проекта через Trunk для production (переопределяем настройки для Docker)
-RUN trunk build --release --dist dist --public-url /
+RUN trunk build --release --dist dist --public-url / && \
+    git rev-parse HEAD > dist/version
 
 FROM nginx:alpine
 WORKDIR /usr/share/nginx/html

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ See [TESTS.md](TESTS.md) for more details about the test suite.
 
 ## Deployment monitor
 
-The monitor workflow (`deploy-monitor.yml`) waits for the `build` workflow to finish. If the deployed version matches the last commit SHA, it sends a Telegram message. Add `TELEGRAM_TOKEN` and `TELEGRAM_CHAT_ID` as repository secrets for notifications.
+The monitor workflow (`deploy-monitor.yml`) waits for the `build` workflow to finish. If the deployed version matches the last commit SHA, it sends a Telegram message. Add `TELEGRAM_TOKEN` and `TELEGRAM_CHAT_ID` as repository secrets for notifications. The build writes the current commit hash to `dist/version`, so the deployed site exposes `/version` with that value.
 
 
 ## Docker


### PR DESCRIPTION
## Summary
- record commit hash in dist/version during build
- copy version file in Docker image
- document `/version` endpoint

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684aa05b09a48331abb35746d42e54b3