### PR TITLE
Fix commit message guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing Guidelines
+
+This document outlines the naming conventions and commit message rules for the repository.
+
+## Naming
+
+- **Modules and files:** use `snake_case`.
+- **Functions and variables:** use `snake_case`.
+- **Structs, enums and traits:** use `CamelCase`.
+- **Constants:** use `UPPER_SNAKE_CASE`.
+- Avoid unclear abbreviations.
+- Prefer short and descriptive names.
+
+## Formatting
+
+- End every text file with a single blank line.
+
+## Commit messages
+
+- Write messages in English.
+- Use the imperative present tense in the title (e.g. "Add renderer tests").
+- Keep the title under 50 characters.
+- If needed, add a body separated by a blank line explaining the motivation.
+- Reference issues or files when relevant.
+- Group multiple changes with bullet points.
+- Wrap body lines at 72 characters.
+


### PR DESCRIPTION
## Summary
- document newline rule for text files in CONTRIBUTING

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684aa1bab5d88331a8b79e1863a4b111