### PR TITLE
Clarify docs-only changes in instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@
   - `cargo fmt --all`
   - `cargo check --tests --benches`
   - `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`
+  - If your changes touch only Markdown files, you can skip the build checks above.
 - Running tests (e.g. `wasm-pack test`) won't work due to wasm; they will run in GitHub Actions.
 - One of the readiness criteria is the absence of formatting issues and linter warnings.
 - Do not suppress warnings about unused code via `#[allow(dead_code)]`. Remove dead code instead.


### PR DESCRIPTION
## Summary
- note that build checks are optional when only Markdown files change

## Testing
- `cargo fmt --all`

------
https://chatgpt.com/codex/tasks/task_e_684ab0aafa408331b1be52c4691caf0c