### PR TITLE
Add version file and display commit hash

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,13 +23,17 @@ jobs:
         run: rm -rf dist
       - name: Build
         run: trunk build --release --dist dist
-      - name: Record version
-        run: echo $GITHUB_SHA > dist/version
+      - name: Save version
+        run: echo ${{ github.sha }} > dist/version
+      - name: Copy dist to docs
+        run: |
+          mkdir -p docs
+          cp -r dist/* docs/
       - name: Commit dist
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git add -f dist
+          git add -f dist docs
           git commit -m "Update dist" || echo "No changes"
           git push
 

--- a/.github/workflows/deploy-monitor.yml
+++ b/.github/workflows/deploy-monitor.yml
@@ -1,4 +1,5 @@
 name: deploy-monitor
+# docs/version contains the SHA of the last commit
 on:
   workflow_run:
     workflows: ["build"]

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ trunk build --dist dist-local
 
 Local builds are saved to `dist-local`. In GitHub Actions the `dist` path is
 used and the files are copied to [`docs/`](docs/) to publish the demo.
+The `docs/version` file stores the SHA of the last commit.
 
 When using Trunk, open **`index.html`** (served automatically when using `trunk serve`). The file contains a Trunk hook so the WASM is loaded for you:
 
@@ -103,7 +104,7 @@ See [TESTS.md](TESTS.md) for more details about the test suite.
 
 ## Deployment monitor
 
-The monitor workflow (`deploy-monitor.yml`) waits for the `build` workflow to finish. If the deployed version matches the last commit SHA, it sends a Telegram message. Add `TELEGRAM_TOKEN` and `TELEGRAM_CHAT_ID` as repository secrets for notifications. The build writes the current commit hash to `dist/version`, so the deployed site exposes `/version` with that value.
+The monitor workflow (`deploy-monitor.yml`) waits for the `build` workflow to finish. If the deployed version matches the last commit SHA, it sends a Telegram message. Add `TELEGRAM_TOKEN` and `TELEGRAM_CHAT_ID` as repository secrets for notifications. The build writes the current commit hash to `docs/version`, so the deployed site exposes `/version` with that value.
 
 
 ## Docker

--- a/docs/index.html
+++ b/docs/index.html
@@ -60,5 +60,13 @@ window.wasmBindings = bindings;
 dispatchEvent(new CustomEvent("TrunkApplicationStarted", {detail: {wasm}}));
 
 </script>
+<p id="version" style="position: fixed; bottom: 0; right: 0; font-size: 0.75em; color: #cccccc;"></p>
+<script>
+fetch('version')
+  .then(r => r.text())
+  .then(t => {
+    document.getElementById('version').textContent = t.trim();
+  });
+</script>
 </body>
-</html> 
+</html>


### PR DESCRIPTION
## Summary
- save commit SHA to dist/version during build
- copy dist to docs and commit
- show current SHA in docs index
- clarify version file in README
- document version file location in monitor workflow

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684aabd59fbc83319048cb47726e9c2d