### PR TITLE
docs: emphasize English naming in AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,4 +17,5 @@
 - Comments in the code and all documentation are written only in English.
 - A summary of available tests and snapshot locations is found in [TESTS.md](TESTS.md).
 - Translate branch and task names into English even if they were originally given in Russian.
+- Always provide branch names and task titles in English, even if the original request is in Russian.
 - If a task description is in Russian, use its English translation when naming branches and in task descriptions.


### PR DESCRIPTION
## Summary
- update agent instructions to stress using English names for branches and tasks

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684ab03f07388331b791b849635f35ea