### PR TITLE
Fix deploy monitor URL

### DIFF
--- a/.github/workflows/deploy-monitor.yml
+++ b/.github/workflows/deploy-monitor.yml
@@ -17,7 +17,7 @@ jobs:
           CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
         run: |
           for i in {1..6}; do
-            version=$(curl -fsSL https://example.com/version)
+            version=$(curl -fsSL https://qqrm.github.io/webgpu-candles/version)
             if [ "$version" = "${{ github.event.workflow_run.head_sha }}" ]; then
               curl -s -X POST "https://api.telegram.org/bot${BOT_TOKEN}/sendMessage" \
                 -d "chat_id=${CHAT_ID}" \


### PR DESCRIPTION
## Summary
- update `deploy-monitor.yml` to check the deployed site version

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684abe4c77a0833190efecdd64069721