### PR TITLE
Fix signal lifetime with global state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,9 +147,9 @@ checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
 
 [[package]]
 name = "bytemuck"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
+checksum = "5c76a5792e44e4abe34d3abf15636779261d45a7450612059293d1d2cfc63422"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -188,9 +188,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "cfg_aliases"
@@ -572,7 +572,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -1302,7 +1302,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.0",
+ "windows-targets 0.53.1",
 ]
 
 [[package]]
@@ -1373,9 +1373,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "metal"
@@ -1637,6 +1637,7 @@ dependencies = [
  "insta",
  "js-sys",
  "leptos",
+ "once_cell",
  "serde",
  "serde_json",
  "strum",
@@ -2131,9 +2132,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "f6397daf94fa90f058bd0fd88429dd9e5738999cca8d701813c80723add80462"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2265,7 +2266,7 @@ dependencies = [
  "serde_spanned",
  "toml_datetime",
  "toml_write",
- "winnow 0.7.10",
+ "winnow 0.7.11",
 ]
 
 [[package]]
@@ -2339,9 +2340,9 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.14"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
 name = "unicode-xid"
@@ -2401,9 +2402,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -2779,9 +2780,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+checksum = "30357ec391cde730f8fbfcdc29adc47518b06504528df977ab5af02ef23fdee9"
 dependencies = [
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
@@ -2900,9 +2901,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
+checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ gloo-timers = { version = "0.3", features = ["futures"] }
 futures = "0.3"
 derive_more = "0.99"
 strum = { version = "0.26", features = ["derive"] }
+once_cell = "1"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/src/global_state.rs
+++ b/src/global_state.rs
@@ -1,0 +1,40 @@
+use crate::app::TooltipData;
+use crate::domain::market_data::TimeInterval;
+use leptos::*;
+use once_cell::sync::OnceCell;
+
+pub struct Globals {
+    pub current_price: RwSignal<f64>,
+    pub candle_count: RwSignal<usize>,
+    pub is_streaming: RwSignal<bool>,
+    pub max_volume: RwSignal<f64>,
+    pub loading_more: RwSignal<bool>,
+    pub tooltip_data: RwSignal<Option<TooltipData>>,
+    pub tooltip_visible: RwSignal<bool>,
+    pub zoom_level: RwSignal<f64>,
+    pub pan_offset: RwSignal<f64>,
+    pub is_dragging: RwSignal<bool>,
+    pub last_mouse_x: RwSignal<f64>,
+    pub last_mouse_y: RwSignal<f64>,
+    pub current_interval: RwSignal<TimeInterval>,
+}
+
+static GLOBALS: OnceCell<Globals> = OnceCell::new();
+
+pub fn globals() -> &'static Globals {
+    GLOBALS.get_or_init(|| Globals {
+        current_price: create_rw_signal(0.0),
+        candle_count: create_rw_signal(0),
+        is_streaming: create_rw_signal(false),
+        max_volume: create_rw_signal(0.0),
+        loading_more: create_rw_signal(false),
+        tooltip_data: create_rw_signal(None),
+        tooltip_visible: create_rw_signal(false),
+        zoom_level: create_rw_signal(1.0),
+        pan_offset: create_rw_signal(0.0),
+        is_dragging: create_rw_signal(false),
+        last_mouse_x: create_rw_signal(0.0),
+        last_mouse_y: create_rw_signal(0.0),
+        current_interval: create_rw_signal(TimeInterval::OneMinute),
+    })
+}

--- a/src/infrastructure/rendering/renderer/geometry.rs
+++ b/src/infrastructure/rendering/renderer/geometry.rs
@@ -45,9 +45,9 @@ pub fn candle_x_position(index: usize, visible_len: usize) -> f32 {
 
 impl WebGpuRenderer {
     pub(super) fn create_geometry(&self, chart: &Chart) -> (Vec<CandleVertex>, ChartUniforms) {
-        use crate::app::CURRENT_INTERVAL;
+        use crate::app::current_interval;
 
-        let interval = CURRENT_INTERVAL.with(|i| i.get_untracked());
+        let interval = current_interval().get_untracked();
         let candles = chart
             .get_series(interval)
             .map(|s| s.get_candles())

--- a/src/infrastructure/rendering/renderer/initialization.rs
+++ b/src/infrastructure/rendering/renderer/initialization.rs
@@ -237,8 +237,8 @@ impl WebGpuRenderer {
 
     pub fn update(&mut self, chart: &Chart) {
         // Simplified update method - just store vertex count for debugging
-        use crate::app::CURRENT_INTERVAL;
-        let interval = CURRENT_INTERVAL.with(|i| i.get_untracked());
+        use crate::app::current_interval;
+        let interval = current_interval().get_untracked();
         let candles = chart
             .get_series(interval)
             .map(|s| s.get_candles())

--- a/src/infrastructure/rendering/renderer/render_loop.rs
+++ b/src/infrastructure/rendering/renderer/render_loop.rs
@@ -23,8 +23,8 @@ impl WebGpuRenderer {
             }
         }
 
-        use crate::app::CURRENT_INTERVAL;
-        let interval = CURRENT_INTERVAL.with(|i| i.get_untracked());
+        use crate::app::current_interval;
+        let interval = current_interval().get_untracked();
         let candle_count = chart
             .get_series(interval)
             .map(|s| s.get_candles().len())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod app;
 pub mod domain;
+pub mod global_state;
 pub mod infrastructure;
 
 // === WASM EXPORTS ===


### PR DESCRIPTION
## Summary
- implement `global_state` module to hold persistent signals
- replace thread-local globals with functions using `OnceCell`
- initialize global access lazily
- update rendering modules to use new accessor

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684ac5ec5b30833192b87d05c1596120