### PR TITLE
Fix pipeline cancellation for new merges

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@ on:
   workflow_dispatch:
 
 permissions: write-all
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/deploy-monitor.yml
+++ b/.github/workflows/deploy-monitor.yml
@@ -5,6 +5,9 @@ on:
     workflows: ["build"]
     types:
       - completed
+concurrency:
+  group: deploy-monitor-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
 
 jobs:
   monitor:


### PR DESCRIPTION
## Summary
- add concurrency to build workflow so new commits cancel running jobs
- add concurrency to deployment monitor

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684acf89a6fc833194a1654f4444b4f0