### PR TITLE
Add WebSocket parsing test

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ src/
 
 For more architectural details see [ARCHITECTURE.md](ARCHITECTURE.md).
 Planned features are listed in [FEATURES.md](FEATURES.md).
+Details on the WebSocket feed are in [WEBSOCKETS.md](WEBSOCKETS.md).
 
 ## Demo
 

--- a/WEBSOCKETS.md
+++ b/WEBSOCKETS.md
@@ -1,0 +1,32 @@
+# WebSocket Integration
+
+This project uses the Binance WebSocket API to receive real‑time candlestick data. The `BinanceWebSocketClient` defined in `src/infrastructure/websocket/binance_client.rs` manages the connection.
+
+## Stream Endpoint
+
+A WebSocket connection is opened to:
+
+```
+wss://stream.binance.com:9443/ws/{symbol}@kline_{interval}
+```
+
+where `symbol` is the trading pair like `BTCUSDT` and `interval` is a value such as `1m`.
+
+## Message Format
+
+Incoming messages contain a `k` field with kline information:
+
+```json
+{
+  "k": {
+    "t": 123456789,
+    "o": "10000.0",
+    "h": "10100.0",
+    "l": "9900.0",
+    "c": "10050.0",
+    "v": "10.0"
+  }
+}
+```
+
+The client parses this structure and converts it to the domain `Candle` type. Values are validated and then propagated to the UI layer for rendering.

--- a/tests/websocket_parse.rs
+++ b/tests/websocket_parse.rs
@@ -1,0 +1,16 @@
+use price_chart_wasm::domain::market_data::{Symbol, TimeInterval};
+use price_chart_wasm::infrastructure::websocket::binance_client::BinanceWebSocketClient;
+use wasm_bindgen_test::*;
+
+#[wasm_bindgen_test]
+fn parses_kline_message() {
+    let client = BinanceWebSocketClient::new(Symbol::from("BTCUSDT"), TimeInterval::OneMinute);
+    let msg = r#"{\"k\":{\"t\":123456789,\"o\":\"10000.0\",\"h\":\"10100.0\",\"l\":\"9900.0\",\"c\":\"10050.0\",\"v\":\"10.0\"}}"#;
+    let candle = client.parse_message(msg).unwrap();
+    assert_eq!(candle.timestamp.value(), 123456789);
+    assert!((candle.ohlcv.open.value() - 10000.0).abs() < f64::EPSILON);
+    assert!((candle.ohlcv.close.value() - 10050.0).abs() < f64::EPSILON);
+    assert!((candle.ohlcv.high.value() - 10100.0).abs() < f64::EPSILON);
+    assert!((candle.ohlcv.low.value() - 9900.0).abs() < f64::EPSILON);
+    assert!((candle.ohlcv.volume.value() - 10.0).abs() < f64::EPSILON);
+}


### PR DESCRIPTION
## Summary
- test Binance message parsing
- document WebSocket integration
- link new doc from README

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684ad4c585e08331bb350ff36bc09c62