### PR TITLE
Fix zoomed candle overlap

### DIFF
--- a/src/infrastructure/rendering/renderer/geometry.rs
+++ b/src/infrastructure/rendering/renderer/geometry.rs
@@ -131,10 +131,8 @@ impl WebGpuRenderer {
         }
 
         // Create vertices for each visible candle
-        let zoom_factor = self.zoom_level.clamp(0.1, 10.0) as f32;
         let step_size = 2.0 / visible_candles.len() as f32;
-        let candle_width =
-            (step_size * zoom_factor * 0.8).clamp(MIN_ELEMENT_WIDTH, MAX_ELEMENT_WIDTH);
+        let candle_width = (step_size * 0.8).clamp(MIN_ELEMENT_WIDTH, MAX_ELEMENT_WIDTH);
 
         for (i, candle) in visible_candles.iter().enumerate() {
             let x = candle_x_position(i, visible_candles.len());
@@ -460,8 +458,7 @@ impl WebGpuRenderer {
         let volume_height = volume_top - volume_bottom;
 
         let step_size = 2.0 / candle_count as f32;
-        let zoom_factor = self.zoom_level.clamp(0.1, 10.0) as f32;
-        let bar_width = (step_size * zoom_factor * 0.8).clamp(MIN_ELEMENT_WIDTH, MAX_ELEMENT_WIDTH); // Та же логика что и для свечей
+        let bar_width = (step_size * 0.8).clamp(MIN_ELEMENT_WIDTH, MAX_ELEMENT_WIDTH);
 
         for (i, candle) in candles.iter().enumerate() {
             let x = candle_x_position(i, candle_count);

--- a/tests/volume_candle_sync.rs
+++ b/tests/volume_candle_sync.rs
@@ -65,9 +65,7 @@ fn volume_width_sync() {
 
     // Проверяем что step_size одинаковый для свечей и volume bars
     let step_size = 2.0 / visible_len as f32;
-    let zoom_factor = 1.0; // По умолчанию
-    let expected_width =
-        (step_size * zoom_factor * 0.8).clamp(MIN_ELEMENT_WIDTH, MAX_ELEMENT_WIDTH);
+    let expected_width = (step_size * 0.8).clamp(MIN_ELEMENT_WIDTH, MAX_ELEMENT_WIDTH);
 
     // Эмулируем логику из кода
     for i in 0..visible_len {

--- a/tests/width_sync_test.rs
+++ b/tests/width_sync_test.rs
@@ -7,15 +7,13 @@ use wasm_bindgen_test::*;
 fn width_calculation_sync() {
     // Тестируем что ширина volume bars и свечей рассчитывается одинаково
     let visible_len = 20;
-    let zoom_level = 1.5f64;
 
     // Эмулируем логику из кода для свечей
     let step_size = 2.0 / visible_len as f32;
-    let zoom_factor = zoom_level.clamp(0.1, 10.0) as f32;
-    let candle_width = (step_size * zoom_factor * 0.8).clamp(MIN_ELEMENT_WIDTH, MAX_ELEMENT_WIDTH);
+    let candle_width = (step_size * 0.8).clamp(MIN_ELEMENT_WIDTH, MAX_ELEMENT_WIDTH);
 
     // Эмулируем логику из кода для volume bars (после исправления)
-    let bar_width = (step_size * zoom_factor * 0.8).clamp(MIN_ELEMENT_WIDTH, MAX_ELEMENT_WIDTH);
+    let bar_width = (step_size * 0.8).clamp(MIN_ELEMENT_WIDTH, MAX_ELEMENT_WIDTH);
 
     // Проверяем что ширина одинаковая
     assert_eq!(


### PR DESCRIPTION
## Summary
- keep candle width proportional to spacing
- sync volume bar width calculations
- update width tests

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684aece76e588331a221250990c19572