### PR TITLE
Fix zoom reset when new data arrives

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1081,6 +1081,11 @@ async fn start_websocket_stream(chart: RwSignal<Chart>, set_status: WriteSignal<
 
             chart.update(|ch| {
                 ch.add_realtime_candle(candle.clone());
+                if (zoom_level().get_untracked() - 1.0).abs() < f64::EPSILON
+                    && pan_offset().get_untracked().abs() < f64::EPSILON
+                {
+                    ch.update_viewport_for_data();
+                }
             });
 
             let count = chart.with(|c| c.get_candle_count());

--- a/src/domain/chart/entities.rs
+++ b/src/domain/chart/entities.rs
@@ -67,8 +67,6 @@ impl Chart {
             base.add_candle(candle.clone());
         }
         self.update_aggregates(candle);
-
-        self.update_viewport_for_data();
     }
 
     /// Get total number of candles

--- a/tests/realtime_viewport.rs
+++ b/tests/realtime_viewport.rs
@@ -1,0 +1,32 @@
+use price_chart_wasm::domain::chart::Chart;
+use price_chart_wasm::domain::chart::value_objects::{ChartType, Viewport};
+use price_chart_wasm::domain::market_data::{Candle, OHLCV, Price, Timestamp, Volume};
+use wasm_bindgen_test::*;
+
+#[wasm_bindgen_test]
+fn add_realtime_candle_keeps_viewport() {
+    let mut chart = Chart::new("test".into(), ChartType::Candlestick, 10);
+    chart.viewport = Viewport {
+        start_time: 100.0,
+        end_time: 200.0,
+        min_price: 10.0,
+        max_price: 20.0,
+        width: 800,
+        height: 600,
+    };
+
+    let original = chart.viewport.clone();
+
+    chart.add_realtime_candle(Candle::new(
+        Timestamp::from_millis(201),
+        OHLCV::new(
+            Price::from(15.0),
+            Price::from(16.0),
+            Price::from(14.0),
+            Price::from(15.5),
+            Volume::from(1.0),
+        ),
+    ));
+
+    assert_eq!(chart.viewport, original);
+}


### PR DESCRIPTION
## Summary
- keep realtime updates from resetting viewport
- skip viewport update inside `add_realtime_candle`
- cover viewport behaviour with a new test

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`

------
https://chatgpt.com/codex/tasks/task_e_684af3473010833189b901353f69a8d1