### PR TITLE
Fix time scale zoom

### DIFF
--- a/tests/visible_range.rs
+++ b/tests/visible_range.rs
@@ -1,0 +1,7 @@
+use price_chart_wasm::app::visible_range;
+
+#[test]
+fn visible_range_basic() {
+    assert_eq!(visible_range(1000, 1.0), (700, 300));
+    assert_eq!(visible_range(50, 2.0), (0, 50));
+}


### PR DESCRIPTION
## Summary
- correct visible candle range based on zoom level
- adjust price axis and time scale calculations
- sync tooltip with zoomed data
- test range calculation

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684b094c8b688331ac40800503d0d4e4