### PR TITLE
Lower verbosity in production logger

### DIFF
--- a/src/infrastructure/mod.rs
+++ b/src/infrastructure/mod.rs
@@ -17,7 +17,7 @@ pub mod services {
         }
 
         pub fn new_production() -> Self {
-            Self::new(LogLevel::Info)
+            Self::new(LogLevel::Warn)
         }
 
         pub fn new_development() -> Self {


### PR DESCRIPTION
## Summary
- decrease ConsoleLogger output level to `Warn`

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684b1277627c8331a991d6874a942d2d