### PR TITLE
Fix pan offset range and add tests

### DIFF
--- a/src/infrastructure/rendering/renderer/geometry.rs
+++ b/src/infrastructure/rendering/renderer/geometry.rs
@@ -73,10 +73,10 @@ impl WebGpuRenderer {
         let _chart_height = 2.0; // NDC height (-1 to 1)
 
         // 🔍 Применяем зум - показываем меньше свечей при увеличении зума
-        let visible_count =
-            ((BASE_CANDLES as f64) / self.zoom_level).max(10.0).min(candle_count as f64) as usize;
-        let start_index = candle_count.saturating_sub(visible_count);
-        let visible_candles: Vec<Candle> = candles.iter().skip(start_index).cloned().collect();
+        let (start_index, visible_count) =
+            crate::app::visible_range(candle_count, self.zoom_level, self.pan_offset);
+        let visible_candles: Vec<Candle> =
+            candles.iter().skip(start_index).take(visible_count).cloned().collect();
 
         let mut vertices = Vec::with_capacity(visible_candles.len() * 24);
 

--- a/tests/visible_range.rs
+++ b/tests/visible_range.rs
@@ -2,6 +2,12 @@ use price_chart_wasm::app::visible_range;
 
 #[test]
 fn visible_range_basic() {
-    assert_eq!(visible_range(1000, 1.0), (700, 300));
-    assert_eq!(visible_range(50, 2.0), (0, 50));
+    assert_eq!(visible_range(1000, 1.0, 0.0), (700, 300));
+    assert_eq!(visible_range(50, 2.0, 0.0), (0, 50));
+}
+
+#[test]
+fn visible_range_with_pan() {
+    assert_eq!(visible_range(1000, 1.0, -50.0), (650, 300));
+    assert_eq!(visible_range(100, 1.0, -200.0), (0, 100));
 }


### PR DESCRIPTION
## Summary
- account for pan offset in `visible_range`
- use updated logic when computing geometry
- cover new function behaviour with unit tests

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`

------
https://chatgpt.com/codex/tasks/task_e_684b12364dbc8331acbdabace4beae80