### PR TITLE
Fix notify bot workflow

### DIFF
--- a/.github/workflows/deploy-monitor.yml
+++ b/.github/workflows/deploy-monitor.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.event.workflow_run.head_sha }}
       - name: Check version
         id: check_version
         run: |


### PR DESCRIPTION
## Summary
- ensure deploy monitor workflow checks out the same commit as build

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684b1d0f87588331bba7b40e7d6ae4d6