### PR TITLE
Improve pan logic and history fetch

### DIFF
--- a/src/infrastructure/rendering/renderer/geometry.rs
+++ b/src/infrastructure/rendering/renderer/geometry.rs
@@ -73,10 +73,11 @@ impl WebGpuRenderer {
         let _chart_height = 2.0; // NDC height (-1 to 1)
 
         // 🔍 Применяем зум - показываем меньше свечей при увеличении зума
+        let candle_vec: Vec<Candle> = candles.iter().cloned().collect();
         let (start_index, visible_count) =
-            crate::app::visible_range(candle_count, self.zoom_level, self.pan_offset);
+            crate::app::visible_range_by_time(&candle_vec, &chart.viewport, self.zoom_level);
         let visible_candles: Vec<Candle> =
-            candles.iter().skip(start_index).take(visible_count).cloned().collect();
+            candle_vec.iter().skip(start_index).take(visible_count).cloned().collect();
 
         let mut vertices = Vec::with_capacity(visible_candles.len() * 24);
 

--- a/tests/history_fetch.rs
+++ b/tests/history_fetch.rs
@@ -1,0 +1,7 @@
+use price_chart_wasm::app::should_fetch_history;
+
+#[test]
+fn history_threshold_check() {
+    assert!(should_fetch_history(-60.0));
+    assert!(!should_fetch_history(-10.0));
+}

--- a/tests/pan_viewport.rs
+++ b/tests/pan_viewport.rs
@@ -1,0 +1,34 @@
+use price_chart_wasm::app::visible_range_by_time;
+use price_chart_wasm::domain::chart::value_objects::Viewport;
+use price_chart_wasm::domain::market_data::{Candle, OHLCV, Price, Timestamp, Volume};
+use wasm_bindgen_test::*;
+
+fn make_candle(i: u64) -> Candle {
+    Candle::new(
+        Timestamp::from_millis(i * 60_000),
+        OHLCV::new(
+            Price::from(1.0),
+            Price::from(1.0),
+            Price::from(1.0),
+            Price::from(1.0),
+            Volume::from(1.0),
+        ),
+    )
+}
+
+#[wasm_bindgen_test]
+fn range_uses_viewport_start_time() {
+    let candles: Vec<Candle> = (0..400).map(make_candle).collect();
+    let vp = Viewport {
+        start_time: 50.0 * 60_000.0,
+        end_time: 350.0 * 60_000.0,
+        min_price: 0.0,
+        max_price: 1.0,
+        width: 800,
+        height: 600,
+    };
+
+    let (start, count) = visible_range_by_time(&candles, &vp, 1.0);
+    assert_eq!(start, 50);
+    assert_eq!(count, 300);
+}


### PR DESCRIPTION
## Summary
- lower threshold for auto-loading history and expose helper
- compute visible range using viewport time
- use new range logic in geometry generation
- test history threshold and viewport-based range

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`
- `cargo test --tests --benches --no-run`


------
https://chatgpt.com/codex/tasks/task_e_684b0e8a32f08331878e7af1a9327cd6