### PR TITLE
Add FPS degradation test

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ wasm-pack test --headless --chrome -- --nocapture
 
 FPS is printed to the console and the `perf.yml` workflow saves the log as an
 artifact. Current metric values are stored in [docs/perf.md](docs/perf.md).
+`tests/performance_limit.rs` logs when FPS drops below 30 for large charts.
+
 
 ## Tests
 

--- a/tests/performance_limit.rs
+++ b/tests/performance_limit.rs
@@ -1,0 +1,57 @@
+use price_chart_wasm::domain::{
+    chart::{Chart, ChartType},
+    market_data::{Candle, OHLCV, Price, Timestamp, Volume},
+};
+use price_chart_wasm::infrastructure::rendering::renderer::WebGpuRenderer;
+use wasm_bindgen::JsCast;
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+fn setup_canvas(id: &str, width: u32, height: u32) {
+    let window = web_sys::window().unwrap();
+    let document = window.document().unwrap();
+    let canvas = document
+        .create_element("canvas")
+        .unwrap()
+        .dyn_into::<web_sys::HtmlCanvasElement>()
+        .unwrap();
+    canvas.set_id(id);
+    canvas.set_width(width);
+    canvas.set_height(height);
+    document.body().unwrap().append_child(&canvas).unwrap();
+}
+
+fn sample_chart(count: usize) -> Chart {
+    let mut chart = Chart::new("perf".to_string(), ChartType::Candlestick, count + 10);
+    for i in 0..count {
+        let ts = Timestamp::from_millis(i as u64);
+        let base = 10000.0 + i as f64;
+        let ohlcv = OHLCV::new(
+            Price::from(base),
+            Price::from(base + 10.0),
+            Price::from(base - 10.0),
+            Price::from(base + 5.0),
+            Volume::from(1.0),
+        );
+        chart.add_candle(Candle::new(ts, ohlcv));
+    }
+    chart
+}
+
+#[wasm_bindgen_test(async)]
+async fn fps_degradation_logging() {
+    setup_canvas("perf-canvas", 800, 600);
+    let mut renderer = WebGpuRenderer::new("perf-canvas", 800, 600).await.unwrap();
+
+    let counts = [1000usize, 5000, 10000, 20000, 50000];
+    for &count in &counts {
+        let chart = sample_chart(count);
+        let fps = renderer.measure_fps(&chart, 30);
+        if fps < 30.0 {
+            web_sys::console::log_1(&format!("⚠ {count} candles: {fps:.2} FPS").into());
+        } else {
+            web_sys::console::log_1(&format!("{count} candles: {fps:.2} FPS").into());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add performance_limit test to log FPS for large charts
- document stress test in README

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`
- `cargo test --tests --benches` *(fails: Exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_684b25b45e3c83319c56f5dcc24705d4