### PR TITLE
use macro for global signals

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -11,13 +11,13 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use wasm_bindgen::JsCast;
 
+use crate::global_signal;
 use crate::{
     domain::{
         chart::Chart,
         logging::{LogComponent, get_logger},
         market_data::{Candle, TimeInterval, value_objects::Symbol},
     },
-    global_state::globals,
     infrastructure::{
         rendering::{
             WebGpuRenderer,
@@ -77,45 +77,19 @@ pub fn visible_range_by_time(
 }
 
 // Helper aliases for global signals
-fn global_current_price() -> RwSignal<f64> {
-    globals().current_price
-}
-fn global_candle_count() -> RwSignal<usize> {
-    globals().candle_count
-}
-fn global_is_streaming() -> RwSignal<bool> {
-    globals().is_streaming
-}
-fn global_max_volume() -> RwSignal<f64> {
-    globals().max_volume
-}
-fn loading_more() -> RwSignal<bool> {
-    globals().loading_more
-}
-fn tooltip_data() -> RwSignal<Option<TooltipData>> {
-    globals().tooltip_data
-}
-fn tooltip_visible() -> RwSignal<bool> {
-    globals().tooltip_visible
-}
-fn zoom_level() -> RwSignal<f64> {
-    globals().zoom_level
-}
-fn pan_offset() -> RwSignal<f64> {
-    globals().pan_offset
-}
-fn is_dragging() -> RwSignal<bool> {
-    globals().is_dragging
-}
-fn last_mouse_x() -> RwSignal<f64> {
-    globals().last_mouse_x
-}
-fn last_mouse_y() -> RwSignal<f64> {
-    globals().last_mouse_y
-}
-pub fn current_interval() -> RwSignal<TimeInterval> {
-    globals().current_interval
-}
+global_signal!(global_current_price, current_price: f64);
+global_signal!(global_candle_count, candle_count: usize);
+global_signal!(global_is_streaming, is_streaming: bool);
+global_signal!(global_max_volume, max_volume: f64);
+global_signal!(loading_more, loading_more: bool);
+global_signal!(tooltip_data, tooltip_data: Option<TooltipData>);
+global_signal!(tooltip_visible, tooltip_visible: bool);
+global_signal!(zoom_level, zoom_level: f64);
+global_signal!(pan_offset, pan_offset: f64);
+global_signal!(is_dragging, is_dragging: bool);
+global_signal!(last_mouse_x, last_mouse_x: f64);
+global_signal!(last_mouse_y, last_mouse_y: f64);
+global_signal!(pub current_interval, current_interval: TimeInterval);
 
 /// 📈 Fetch additional history and prepend it to the list
 fn fetch_more_history(chart: RwSignal<Chart>, set_status: WriteSignal<String>) {

--- a/src/app.rs
+++ b/src/app.rs
@@ -11,7 +11,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use wasm_bindgen::JsCast;
 
-use crate::global_signal;
+use crate::global_signals;
 use crate::{
     domain::{
         chart::Chart,
@@ -77,19 +77,21 @@ pub fn visible_range_by_time(
 }
 
 // Helper aliases for global signals
-global_signal!(global_current_price, current_price: f64);
-global_signal!(global_candle_count, candle_count: usize);
-global_signal!(global_is_streaming, is_streaming: bool);
-global_signal!(global_max_volume, max_volume: f64);
-global_signal!(loading_more, loading_more: bool);
-global_signal!(tooltip_data, tooltip_data: Option<TooltipData>);
-global_signal!(tooltip_visible, tooltip_visible: bool);
-global_signal!(zoom_level, zoom_level: f64);
-global_signal!(pan_offset, pan_offset: f64);
-global_signal!(is_dragging, is_dragging: bool);
-global_signal!(last_mouse_x, last_mouse_x: f64);
-global_signal!(last_mouse_y, last_mouse_y: f64);
-global_signal!(pub current_interval, current_interval: TimeInterval);
+global_signals! {
+    global_current_price => current_price: f64,
+    global_candle_count => candle_count: usize,
+    global_is_streaming => is_streaming: bool,
+    global_max_volume => max_volume: f64,
+    loading_more => loading_more: bool,
+    tooltip_data => tooltip_data: Option<TooltipData>,
+    tooltip_visible => tooltip_visible: bool,
+    zoom_level => zoom_level: f64,
+    pan_offset => pan_offset: f64,
+    is_dragging => is_dragging: bool,
+    last_mouse_x => last_mouse_x: f64,
+    last_mouse_y => last_mouse_y: f64,
+    pub current_interval => current_interval: TimeInterval,
+}
 
 /// 📈 Fetch additional history and prepend it to the list
 fn fetch_more_history(chart: RwSignal<Chart>, set_status: WriteSignal<String>) {

--- a/src/domain/chart/entities.rs
+++ b/src/domain/chart/entities.rs
@@ -60,7 +60,6 @@ impl Chart {
         // Update the viewport
         self.update_viewport_for_data();
     }
-
     /// Add a new candle in real time
     pub fn add_realtime_candle(&mut self, candle: Candle) {
         if let Some(base) = self.series.get_mut(&TimeInterval::OneMinute) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod app;
 pub mod domain;
 pub mod global_state;
 pub mod infrastructure;
+pub mod macros;
 
 // === WASM EXPORTS ===
 use leptos::*;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -8,3 +8,21 @@ macro_rules! global_signal {
         }
     };
 }
+
+/// Generate multiple global signal accessors at once.
+///
+/// Usage:
+/// `global_signals! {
+///     pub fn1 => field1: Type1,
+///     fn2 => field2: Type2,
+/// }`
+#[macro_export]
+macro_rules! global_signals {
+    ( $( $vis:vis $name:ident => $field:ident : $ty:ty ),+ $(,)? ) => {
+        $(
+            $vis fn $name() -> ::leptos::RwSignal<$ty> {
+                $crate::global_state::globals().$field
+            }
+        )+
+    };
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,10 @@
+/// Helper macro to define functions returning global signals.
+/// Usage: `global_signal!(fn_name, field: Type);`
+#[macro_export]
+macro_rules! global_signal {
+    ($vis:vis $name:ident, $field:ident : $ty:ty) => {
+        $vis fn $name() -> ::leptos::RwSignal<$ty> {
+            $crate::global_state::globals().$field
+        }
+    };
+}


### PR DESCRIPTION
## Summary
- add new `global_signal` macro
- generate global signal helpers in `app.rs`
- expose new macros module

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684b3681e9008331b52e217c7580ac57