### PR TITLE
Initialize global Binance clients

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,12 @@ jobs:
         with:
           toolchain: stable
           targets: wasm32-unknown-unknown
+      - name: Install rustup if needed
+        run: |
+          if ! command -v rustup &>/dev/null; then
+            curl --proto '=https' --tlsv1.2 --retry 10 --retry-delay 5 --retry-connrefused --location --silent --show-error --fail https://sh.rustup.rs | sh -s -- --default-toolchain none -y
+            echo "$CARGO_HOME/bin" >> $GITHUB_PATH
+          fi
       - name: Install wasm-pack
         run: cargo install wasm-pack
       - name: Install wasm-tools
@@ -21,7 +27,7 @@ jobs:
       - name: Cargo clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
       - name: Run tests with coverage
-        run: wasm-pack test --headless --chrome --coverage
+        run: wasm-pack test --headless --chrome --coverage --log-level debug
       - name: Generate lcov
         run: wasm-tools coverage target/wasm32-unknown-unknown/debug/deps/*.wasm > lcov.info
       - name: Upload coverage

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1302,7 +1302,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.1",
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -1803,9 +1803,9 @@ checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.12"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
+checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
  "bitflags 2.9.1",
 ]
@@ -2780,9 +2780,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.1"
+version = "0.53.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30357ec391cde730f8fbfcdc29adc47518b06504528df977ab5af02ef23fdee9"
+checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
 dependencies = [
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",

--- a/src/app.rs
+++ b/src/app.rs
@@ -3,12 +3,14 @@
 //! Handles canvas interactions, zoom/pan logic and connects to the
 //! WebSocket stream providing market data.
 
+use futures::lock::Mutex;
 use js_sys;
 use leptos::html::Canvas;
 use leptos::spawn_local_with_current_owner;
 use leptos::*;
 use std::cell::RefCell;
 use std::rc::Rc;
+use std::sync::Arc;
 use wasm_bindgen::JsCast;
 
 use crate::{
@@ -23,7 +25,7 @@ use crate::{
             WebGpuRenderer,
             renderer::{set_global_renderer, with_global_renderer},
         },
-        websocket::BinanceWebSocketClient,
+        websocket::{BinanceWebSocketClient, get_global_rest_client, get_global_stream_client},
     },
 };
 
@@ -136,8 +138,17 @@ fn fetch_more_history(chart: RwSignal<Chart>, set_status: WriteSignal<String>) {
     loading_more().set(true);
 
     let _ = spawn_local_with_current_owner(async move {
-        let client = BinanceWebSocketClient::new(Symbol::from("BTCUSDT"), TimeInterval::OneMinute);
-        match client.fetch_historical_data_before(end_time, 300).await {
+        let client_arc = get_global_rest_client().unwrap_or_else(|| {
+            Arc::new(Mutex::new(BinanceWebSocketClient::new(
+                Symbol::from("BTCUSDT"),
+                TimeInterval::OneMinute,
+            )))
+        });
+        let result = {
+            let client = client_arc.lock().await;
+            client.fetch_historical_data_before(end_time, 300).await
+        };
+        match result {
             Ok(mut new_candles) => {
                 new_candles.sort_by(|a, b| a.timestamp.value().cmp(&b.timestamp.value()));
                 chart.update(|ch| {
@@ -1083,8 +1094,10 @@ async fn start_websocket_stream(chart: RwSignal<Chart>, set_status: WriteSignal<
     let symbol = Symbol::from("BTCUSDT");
     let interval = TimeInterval::OneMinute;
 
-    // Create a client for data loading
-    let ws_client = BinanceWebSocketClient::new(symbol, interval);
+    // Use the global REST client for history
+    let rest_client_arc = get_global_rest_client().unwrap_or_else(|| {
+        Arc::new(Mutex::new(BinanceWebSocketClient::new(symbol.clone(), interval)))
+    });
 
     // Set the streaming status
     global_is_streaming().set(false);
@@ -1092,7 +1105,11 @@ async fn start_websocket_stream(chart: RwSignal<Chart>, set_status: WriteSignal<
     // 📈 First load historical data
     set_status.set("📈 Loading historical data...".to_string());
 
-    match ws_client.fetch_historical_data(300).await {
+    let hist_res = {
+        let client = rest_client_arc.lock().await;
+        client.fetch_historical_data(300).await
+    };
+    match hist_res {
         Ok(historical_candles) => {
             get_logger().info(
                 LogComponent::Presentation("WebSocketStream"),
@@ -1131,8 +1148,12 @@ async fn start_websocket_stream(chart: RwSignal<Chart>, set_status: WriteSignal<
     set_status.set("🔌 Starting WebSocket stream...".to_string());
     global_is_streaming().set(true);
 
-    let mut ws_client =
-        BinanceWebSocketClient::new(Symbol::from("BTCUSDT"), TimeInterval::OneMinute);
+    let stream_client_arc = get_global_stream_client().unwrap_or_else(|| {
+        Arc::new(Mutex::new(BinanceWebSocketClient::new(
+            Symbol::from("BTCUSDT"),
+            TimeInterval::OneMinute,
+        )))
+    });
 
     let _ = spawn_local_with_current_owner(async move {
         let handler = move |candle: Candle| {
@@ -1165,7 +1186,11 @@ async fn start_websocket_stream(chart: RwSignal<Chart>, set_status: WriteSignal<
             set_status.set("🌐 WebSocket LIVE • Real-time updates".to_string());
         };
 
-        if let Err(e) = ws_client.start_stream(handler).await {
+        let result = {
+            let mut client = stream_client_arc.lock().await;
+            client.start_stream(handler).await
+        };
+        if let Err(e) = result {
             set_status.set(format!("❌ WebSocket error: {}", e));
             global_is_streaming().set(false);
         }

--- a/src/infrastructure/websocket/client_handle.rs
+++ b/src/infrastructure/websocket/client_handle.rs
@@ -1,0 +1,23 @@
+use crate::infrastructure::websocket::BinanceWebSocketClient;
+use futures::lock::Mutex;
+use once_cell::sync::OnceCell;
+use std::sync::Arc;
+
+static REST_CLIENT: OnceCell<Arc<Mutex<BinanceWebSocketClient>>> = OnceCell::new();
+static STREAM_CLIENT: OnceCell<Arc<Mutex<BinanceWebSocketClient>>> = OnceCell::new();
+
+pub fn set_global_rest_client(client: Arc<Mutex<BinanceWebSocketClient>>) {
+    let _ = REST_CLIENT.set(client);
+}
+
+pub fn set_global_stream_client(client: Arc<Mutex<BinanceWebSocketClient>>) {
+    let _ = STREAM_CLIENT.set(client);
+}
+
+pub fn get_global_rest_client() -> Option<Arc<Mutex<BinanceWebSocketClient>>> {
+    REST_CLIENT.get().cloned()
+}
+
+pub fn get_global_stream_client() -> Option<Arc<Mutex<BinanceWebSocketClient>>> {
+    STREAM_CLIENT.get().cloned()
+}

--- a/src/infrastructure/websocket/mod.rs
+++ b/src/infrastructure/websocket/mod.rs
@@ -3,8 +3,13 @@
 //! Currently this module provides a client for Binance streaming data.
 
 pub mod binance_client;
+pub mod client_handle;
 pub mod dto;
 
 // Clean exports - only WebSocket client
 pub use binance_client::*;
+pub use client_handle::{
+    get_global_rest_client, get_global_stream_client, set_global_rest_client,
+    set_global_stream_client,
+};
 pub use dto::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,9 @@ pub mod global_state;
 pub mod infrastructure;
 
 // === WASM EXPORTS ===
+use futures::lock::Mutex;
 use leptos::*;
+use std::sync::Arc;
 use wasm_bindgen::prelude::*;
 
 #[cfg(target_arch = "wasm32")]
@@ -24,6 +26,19 @@ pub fn start_app() {
 
     // Initialize infrastructure services
     crate::infrastructure::initialize_infrastructure_services();
+
+    // Initialize global clients
+    use crate::domain::market_data::{Symbol, TimeInterval};
+    use crate::infrastructure::websocket::{
+        BinanceWebSocketClient, set_global_rest_client, set_global_stream_client,
+    };
+    let symbol = Symbol::from("BTCUSDT");
+    let interval = TimeInterval::OneMinute;
+    set_global_rest_client(Arc::new(Mutex::new(BinanceWebSocketClient::new(
+        symbol.clone(),
+        interval,
+    ))));
+    set_global_stream_client(Arc::new(Mutex::new(BinanceWebSocketClient::new(symbol, interval))));
 
     // Mount Leptos app to body
     web_sys::console::log_1(&"🎯 Mounting Leptos app...".into());


### PR DESCRIPTION
## Summary
- create new `client_handle` module for global Binance clients
- initialize global clients at app start
- fetch history and start stream via global clients

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`

------
https://chatgpt.com/codex/tasks/task_e_684b30e33958833183af2f79b155165b