### PR TITLE
Remove unused coverage flag

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,14 +17,10 @@ jobs:
         with:
           toolchain: stable
           targets: wasm32-unknown-unknown
-      - name: Install wasm-pack
-        run: cargo install wasm-pack
-      - name: Install wasm-tools
-        run: cargo install wasm-tools
-      - name: Run tests
-        run: wasm-pack test --headless --chrome --coverage
-      - name: Generate lcov
-        run: wasm-tools coverage target/wasm32-unknown-unknown/debug/deps/*.wasm > lcov.info
+      - name: Install cargo-llvm-cov
+        run: cargo install cargo-llvm-cov
+      - name: Generate coverage
+        run: cargo llvm-cov --workspace --lcov --output-path lcov.info
       - name: Compute coverage
         run: |
           python - <<'PY'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,20 +18,11 @@ jobs:
           fi
       - name: Install wasm-pack
         run: cargo install wasm-pack --version 0.10.3
-      - name: Install wasm-tools
-        run: cargo install wasm-tools
       - name: Update dependencies
         run: cargo update
       - name: Cargo check
         run: cargo check --all-targets
       - name: Cargo clippy
         run: cargo clippy --all-targets --all-features -- -D warnings || echo 'Clippy warnings found'
-      - name: Run tests with coverage
-        run: wasm-pack test --headless --chrome --coverage --log-level debug
-      - name: Generate lcov
-        run: wasm-tools coverage target/wasm32-unknown-unknown/debug/deps/*.wasm > lcov.info
-      - name: Upload coverage
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage
-          path: lcov.info
+      - name: Run tests
+        run: wasm-pack test --headless --chrome --log-level debug

--- a/README.md
+++ b/README.md
@@ -113,11 +113,10 @@ npm test
 
 See [TESTS.md](TESTS.md) for more details about the test suite.
 
-Coverage can be collected with:
+Coverage can be collected with `cargo-llvm-cov`:
 
 ```bash
-wasm-pack test --headless --chrome --coverage
-wasm-tools coverage target/wasm32-unknown-unknown/debug/deps/*.wasm > lcov.info
+cargo llvm-cov --workspace --lcov --output-path lcov.info
 ```
 
 The generated `lcov.info` file can be uploaded by CI.


### PR DESCRIPTION
## Summary
- update README instructions to use `cargo-llvm-cov`
- simplify test workflow
- use `cargo llvm-cov` in the coverage workflow

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`

------
https://chatgpt.com/codex/tasks/task_e_684bc96b08ac8331a9aa99e1e5de4282