### PR TITLE
Add Telegram deployment failure alerts

### DIFF
--- a/.github/workflows/deploy-monitor.yml
+++ b/.github/workflows/deploy-monitor.yml
@@ -32,10 +32,18 @@ jobs:
           echo "Version not updated"
           exit 1
 
-      - name: Notify
+      - name: Notify success
         if: success() && hashFiles('scripts/notify_bot.py') != ''
         env:
           NOTIFY_MESSAGE: "Deployment succeeded: ${{ steps.check_version.outputs.version }}"
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        run: python scripts/notify_bot.py
+
+      - name: Notify failure
+        if: failure() && hashFiles('scripts/notify_bot.py') != ''
+        env:
+          NOTIFY_MESSAGE: "Deployment failed"
           TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
         run: python scripts/notify_bot.py


### PR DESCRIPTION
## Summary
- notify Telegram bot when deployment monitor fails

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684bcc6a17408331a2e7c450066cc834