### PR TITLE
Add indicator vertex tests

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -1,10 +1,11 @@
 # Test Suite
 
-The `tests/` folder contains integration tests for the main components. Currently it has three files:
+The `tests/` folder contains unit and integration tests for the main components. Key files include:
 
 - `viewport.rs` — verifies `Viewport` methods (coordinate conversions, panning and zoom)
 - `geometry.rs` — generates candle vertices and compares them with a snapshot
 - `offset.rs` — checks candle positioning by index and count
+- `indicator_vertices.rs` — validates vertices for indicator and current price lines
 
 Snapshot fixtures are stored in `tests/fixtures`.
 

--- a/tests/indicator_vertices.rs
+++ b/tests/indicator_vertices.rs
@@ -1,0 +1,19 @@
+use price_chart_wasm::infrastructure::rendering::gpu_structures::{CandleGeometry, IndicatorType};
+use wasm_bindgen_test::*;
+
+#[wasm_bindgen_test]
+fn current_price_line_vertices() {
+    let verts = CandleGeometry::create_current_price_line(0.5, 0.2);
+    assert_eq!(verts.len(), 6);
+    assert!((verts[0].position_x + 1.0).abs() < f32::EPSILON);
+    assert!((verts[0].position_y - 0.4).abs() < f32::EPSILON);
+    assert!((verts[0].color_type - 7.0).abs() < f32::EPSILON);
+}
+
+#[wasm_bindgen_test]
+fn indicator_line_vertex_count() {
+    let points = [(-1.0, 0.0), (0.0, 0.5), (1.0, 0.0)];
+    let verts = CandleGeometry::create_indicator_line_vertices(&points, IndicatorType::SMA20, 0.1);
+    assert_eq!(verts.len(), (points.len() - 1) * 6);
+    assert!((verts[0].color_type - 2.0).abs() < f32::EPSILON);
+}


### PR DESCRIPTION
## Summary
- add tests for indicator line and price line vertices
- document new test file in TESTS.md

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`

------
https://chatgpt.com/codex/tasks/task_e_684bd82cb9d48331a2956f92c9b875c4