### PR TITLE
Handle missing Telegram config

### DIFF
--- a/scripts/notify_bot.py
+++ b/scripts/notify_bot.py
@@ -2,14 +2,18 @@
 """Deployment notification helper."""
 
 import os
+import sys
 import urllib.parse
 import urllib.request
 
 
 def send_telegram(message: str) -> None:
     """Send a Telegram message using Bot API."""
-    token = os.environ["TELEGRAM_TOKEN"]
-    chat_id = os.environ["TELEGRAM_CHAT_ID"]
+    token = os.getenv("TELEGRAM_TOKEN")
+    chat_id = os.getenv("TELEGRAM_CHAT_ID")
+    if not token or not chat_id:
+        print("Missing TELEGRAM_TOKEN or TELEGRAM_CHAT_ID environment variables.")
+        sys.exit(1)
     data = urllib.parse.urlencode({"chat_id": chat_id, "text": message}).encode()
     url = f"https://api.telegram.org/bot{token}/sendMessage"
     try:

--- a/scripts/tests/test_notify_bot.py
+++ b/scripts/tests/test_notify_bot.py
@@ -1,0 +1,24 @@
+import io
+import os
+import unittest
+from contextlib import redirect_stdout
+
+import scripts.notify_bot as notify_bot
+
+
+class NotifyBotTests(unittest.TestCase):
+    def test_missing_environment_variables(self):
+        os.environ.pop("TELEGRAM_TOKEN", None)
+        os.environ.pop("TELEGRAM_CHAT_ID", None)
+        buf = io.StringIO()
+        with self.assertRaises(SystemExit) as cm, redirect_stdout(buf):
+            notify_bot.send_telegram("Test")
+        self.assertEqual(cm.exception.code, 1)
+        output = buf.getvalue()
+        self.assertIn(
+            "Missing TELEGRAM_TOKEN or TELEGRAM_CHAT_ID", output
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- switch `send_telegram` to `os.getenv`
- exit with error when Telegram variables are missing
- test missing environment variables

## Testing
- `python3 -m unittest scripts.tests.test_notify_bot`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684bff1a246883318d04d240a996aed4