### PR TITLE
Update Deployment monitor docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,14 @@ The `coverage` workflow publishes the latest percentage to `docs/coverage.md`.
 
 The monitor workflow (`deploy-monitor.yml`) waits for the `build` workflow to finish. If the deployed version matches the last commit SHA, it sends a Telegram message. Add `TELEGRAM_TOKEN` and `TELEGRAM_CHAT_ID` as repository secrets for notifications. The build writes the current commit hash to `docs/version`, so the deployed site exposes `/version` with that value.
 
+To send a notification manually run:
+
+```bash
+TELEGRAM_TOKEN=... TELEGRAM_CHAT_ID=... python scripts/notify_bot.py
+```
+
+Set `NOTIFY_MESSAGE` to override the default text. This lets you test the script locally without triggering the workflow.
+
 
 ## Docker
 


### PR DESCRIPTION
## Summary
- document how to manually invoke `notify_bot.py` in Deployment monitor section
- mention using `NOTIFY_MESSAGE` to test the script locally

## Testing
- `git commit -m "docs: clarify manual deployment notifications"`

------
https://chatgpt.com/codex/tasks/task_e_684bff0ff2208331ad5c2bd95df2d17d