### PR TITLE
Add Telegram bot unit tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,8 @@ jobs:
         run: cargo check --all-targets
       - name: Cargo clippy
         run: cargo clippy --all-targets --all-features -- -D warnings || echo 'Clippy warnings found'
+      - name: Python notify bot tests
+        run: python -m unittest discover -s tests -p 'test_notify_bot.py'
       - name: Run tests
         run: wasm-pack test --headless --chrome
       - name: Generate lcov

--- a/tests/test_notify_bot.py
+++ b/tests/test_notify_bot.py
@@ -1,0 +1,34 @@
+import os
+import unittest
+from unittest.mock import patch, MagicMock
+
+import scripts.notify_bot as notify_bot
+import urllib.parse
+
+
+class TestNotifyBot(unittest.TestCase):
+    @patch('urllib.request.urlopen')
+    def test_send_telegram_success(self, mock_urlopen):
+        mock_response = MagicMock(status=200)
+        mock_urlopen.return_value = mock_response
+        with patch.dict(os.environ, {'TELEGRAM_TOKEN': 't', 'TELEGRAM_CHAT_ID': '1'}, clear=True):
+            notify_bot.send_telegram('hello')
+            expected_data = urllib.parse.urlencode({'chat_id': '1', 'text': 'hello'}).encode()
+            mock_urlopen.assert_called_once_with('https://api.telegram.org/bott/sendMessage', data=expected_data)
+
+    def test_send_telegram_missing_env(self):
+        with patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(KeyError):
+                notify_bot.send_telegram('msg')
+
+    @patch('urllib.request.urlopen', side_effect=Exception('err'))
+    def test_send_telegram_error(self, mock_urlopen):
+        with patch.dict(os.environ, {'TELEGRAM_TOKEN': 't', 'TELEGRAM_CHAT_ID': '1'}, clear=True):
+            with patch('builtins.print') as mock_print:
+                notify_bot.send_telegram('boom')
+                mock_urlopen.assert_called_once()
+                mock_print.assert_called()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add Python unit tests for notify bot
- run the new tests in CI

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`
- `python -m unittest discover -s tests -p 'test_notify_bot.py'`

------
https://chatgpt.com/codex/tasks/task_e_684bff0baa2483318df9b5d358ecbce5