### PR TITLE
Add Telegram response check

### DIFF
--- a/scripts/notify_bot.py
+++ b/scripts/notify_bot.py
@@ -17,9 +17,13 @@ def send_telegram(message: str) -> None:
     data = urllib.parse.urlencode({"chat_id": chat_id, "text": message}).encode()
     url = f"https://api.telegram.org/bot{token}/sendMessage"
     try:
-        urllib.request.urlopen(url, data=data)
+        with urllib.request.urlopen(url, data=data) as resp:
+            if resp.status != 200:
+                print(f"Failed to send Telegram message: HTTP {resp.status}")
+                sys.exit(1)
     except Exception as err:
         print(f"Failed to send Telegram message: {err}")
+        sys.exit(1)
 
 
 def main() -> None:

--- a/scripts/tests/test_notify_bot.py
+++ b/scripts/tests/test_notify_bot.py
@@ -1,6 +1,7 @@
 import io
 import os
 import unittest
+from unittest import mock
 from contextlib import redirect_stdout
 
 import scripts.notify_bot as notify_bot
@@ -18,6 +19,33 @@ class NotifyBotTests(unittest.TestCase):
         self.assertIn(
             "Missing TELEGRAM_TOKEN or TELEGRAM_CHAT_ID", output
         )
+
+    def test_unsuccessful_response(self):
+        os.environ["TELEGRAM_TOKEN"] = "token"
+        os.environ["TELEGRAM_CHAT_ID"] = "chat"
+
+        class FakeResponse:
+            def __init__(self, status: int):
+                self.status = status
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+        def fake_urlopen(url, data=None):
+            return FakeResponse(500)
+
+        buf = io.StringIO()
+        with mock.patch(
+            "urllib.request.urlopen", side_effect=fake_urlopen
+        ), self.assertRaises(SystemExit) as cm, redirect_stdout(buf):
+            notify_bot.send_telegram("Test")
+
+        self.assertEqual(cm.exception.code, 1)
+        output = buf.getvalue()
+        self.assertIn("Failed to send Telegram message: HTTP 500", output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- use `with urllib.request.urlopen` in notify_bot
- return error and exit when HTTP status is not 200
- cover failure case in `test_notify_bot`

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`
- `python -m unittest discover -s scripts/tests -v`

------
https://chatgpt.com/codex/tasks/task_e_684c004e90d88331a85207503508f83e