### PR TITLE
Add button to reset pan

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -855,7 +855,10 @@ fn ChartContainer() -> impl IntoView {
         <div class="chart-container">
             <div style="display:flex;justify-content:space-between;margin-bottom:8px;">
                 <AssetSelector chart=chart set_status=set_status />
-                <TimeframeSelector />
+                <div style="display:flex;gap:6px;">
+                    <TimeframeSelector />
+                    <CurrentTimeButton chart=chart />
+                </div>
             </div>
 
             <div style="display: flex; flex-direction: row; align-items: flex-start;">
@@ -1014,6 +1017,29 @@ fn TimeframeSelector() -> impl IntoView {
                 }
             />
         </div>
+    }
+}
+
+#[component]
+fn CurrentTimeButton(chart: RwSignal<Chart>) -> impl IntoView {
+    view! {
+        <button
+            style="padding:4px 6px;border:none;border-radius:4px;background:#2a5298;color:white;"
+            on:click=move |_| {
+                pan_offset().set(0.0);
+                chart.update(|c| c.update_viewport_for_data());
+                chart.with_untracked(|c| {
+                    if c.get_candle_count() > 0 {
+                        with_global_renderer(|r| {
+                            r.set_zoom_params(zoom_level().with_untracked(|z| *z), 0.0);
+                            let _ = r.render(c);
+                        });
+                    }
+                });
+            }
+        >
+            "Now"
+        </button>
     }
 }
 

--- a/tests/current_time.rs
+++ b/tests/current_time.rs
@@ -1,0 +1,33 @@
+use price_chart_wasm::app::visible_range;
+use price_chart_wasm::domain::chart::{Chart, value_objects::ChartType};
+use price_chart_wasm::domain::market_data::{Candle, OHLCV, Price, Timestamp, Volume};
+
+fn make_candle(i: u64) -> Candle {
+    Candle::new(
+        Timestamp::from_millis(i * 60_000),
+        OHLCV::new(
+            Price::from(1.0),
+            Price::from(1.0),
+            Price::from(1.0),
+            Price::from(1.0),
+            Volume::from(1.0),
+        ),
+    )
+}
+
+#[test]
+fn pan_reset_shows_latest_candle() {
+    let mut chart = Chart::new("test".to_string(), ChartType::Candlestick, 400);
+    for i in 0..400 {
+        chart.add_candle(make_candle(i as u64));
+    }
+
+    let pan = 0.0;
+    chart.update_viewport_for_data();
+
+    let len = chart.get_candle_count();
+    let (start, visible) = visible_range(len, 1.0, pan);
+
+    assert_eq!(pan, 0.0);
+    assert_eq!(start + visible - 1, len - 1);
+}


### PR DESCRIPTION
## Summary
- create `CurrentTimeButton` component
- render new button next to the timeframe selector
- check that resetting the pan shows the latest candle

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684c05d9e9608331a17c54742b6635be