### PR TITLE
Add GPU memory reporting

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -558,6 +558,7 @@ fn ChartContainer() -> impl IntoView {
                         let renderer_rc = Rc::new(RefCell::new(webgpu_renderer));
                         set_renderer.set(Some(renderer_rc.clone()));
                         set_global_renderer(renderer_rc.clone());
+                        let _ = renderer_rc.borrow().log_gpu_memory_usage();
                         set_status.set("✅ WebGPU renderer ready".to_string());
 
                         // Start WebSocket after the renderer is initialized

--- a/src/infrastructure/rendering/renderer/initialization.rs
+++ b/src/infrastructure/rendering/renderer/initialization.rs
@@ -58,6 +58,15 @@ impl WebGpuRenderer {
             .await
             .map_err(|e| JsValue::from_str(&format!("Failed to find adapter: {:?}", e)))?;
 
+        let adapter_info = adapter.get_info();
+        get_logger().info(
+            LogComponent::Infrastructure("WebGpuRenderer"),
+            &format!(
+                "\u{1f5a5}\u{fe0f} Adapter: {}, driver: {}, type: {:?}",
+                adapter_info.name, adapter_info.driver_info, adapter_info.device_type
+            ),
+        );
+
         // Get the adapter's supported limits to ensure compatibility
         let supported_limits = adapter.limits();
 
@@ -199,7 +208,7 @@ impl WebGpuRenderer {
             "✅ Full WebGPU renderer initialized successfully.",
         );
 
-        Ok(Self {
+        let renderer = Self {
             _canvas_id: canvas.id(),
             width,
             height,
@@ -223,7 +232,11 @@ impl WebGpuRenderer {
             last_frame_time: 0.0,
             fps_log: VecDeque::new(),
             line_visibility: LineVisibility::default(),
-        })
+        };
+
+        renderer.log_gpu_memory_usage();
+
+        Ok(renderer)
     }
 
     pub fn resize(&mut self, new_width: u32, new_height: u32) {

--- a/src/infrastructure/rendering/renderer/render_loop.rs
+++ b/src/infrastructure/rendering/renderer/render_loop.rs
@@ -160,6 +160,30 @@ impl WebGpuRenderer {
         .to_string()
     }
 
+    /// Log GPU memory usage and return statistics as JSON
+    pub fn log_gpu_memory_usage(&self) -> String {
+        if let Some(report) = self.device.generate_allocator_report() {
+            let reserved = report.total_reserved_bytes / 1024 / 1024;
+            let allocated = report.total_allocated_bytes / 1024 / 1024;
+            let msg = format!(
+                "\u{1f4c8} GPU memory reserved: {} MB, allocated: {} MB",
+                reserved, allocated
+            );
+            get_logger().info(LogComponent::Infrastructure("WebGpuRenderer"), &msg);
+            serde_json::json!({
+                "reserved_mb": reserved,
+                "allocated_mb": allocated
+            })
+            .to_string()
+        } else {
+            get_logger().warn(
+                LogComponent::Infrastructure("WebGpuRenderer"),
+                "\u{26a0}\u{fe0f} GPU memory report unavailable",
+            );
+            "{}".to_string()
+        }
+    }
+
     /// Toggle indicator line visibility
     pub fn toggle_line_visibility(&mut self, line_name: &str) {
         match line_name {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,4 +73,12 @@ pub fn get_renderer_performance() -> String {
         .unwrap_or_else(|| "{\"backend\":\"WebGPU\",\"status\":\"not_ready\"}".to_string())
 }
 
+/// Get GPU memory statistics
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen]
+pub fn get_gpu_memory_usage() -> String {
+    crate::infrastructure::rendering::renderer::with_global_renderer(|r| r.log_gpu_memory_usage())
+        .unwrap_or_else(|| "{}".to_string())
+}
+
 // Clean WASM exports only

--- a/tests/gpu_memory.rs
+++ b/tests/gpu_memory.rs
@@ -1,0 +1,27 @@
+use price_chart_wasm::infrastructure::rendering::renderer::WebGpuRenderer;
+use wasm_bindgen::JsCast;
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+fn setup_canvas(id: &str) {
+    let window = web_sys::window().unwrap();
+    let document = window.document().unwrap();
+    let canvas = document
+        .create_element("canvas")
+        .unwrap()
+        .dyn_into::<web_sys::HtmlCanvasElement>()
+        .unwrap();
+    canvas.set_id(id);
+    canvas.set_width(10);
+    canvas.set_height(10);
+    document.body().unwrap().append_child(&canvas).unwrap();
+}
+
+#[wasm_bindgen_test(async)]
+async fn memory_usage_returns_string() {
+    setup_canvas("mem-canvas");
+    let renderer = WebGpuRenderer::new("mem-canvas", 10, 10).await.unwrap();
+    let stats = renderer.log_gpu_memory_usage();
+    assert!(!stats.is_empty());
+}


### PR DESCRIPTION
## Summary
- log adapter info during WebGPU initialization
- expose WebGpuRenderer::log_gpu_memory_usage
- call log_gpu_memory_usage after initialization and from UI
- export get_gpu_memory_usage for JavaScript
- test memory usage helper

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`

------
https://chatgpt.com/codex/tasks/task_e_684c05daf04c8331863c055a0fbf5594