### PR TITLE
Fix WebGPU buffer initialization

### DIFF
--- a/src/infrastructure/rendering/renderer/geometry.rs
+++ b/src/infrastructure/rendering/renderer/geometry.rs
@@ -82,6 +82,8 @@ impl WebGpuRenderer {
         let visible_candles: Vec<Candle> =
             candle_vec.iter().skip(start_index).take(visible_count).cloned().collect();
 
+        let mut vertices = Vec::with_capacity(visible_candles.len() * 24);
+
         // Use viewport values for vertical panning
         let mut min_price = chart.viewport.min_price;
         let mut max_price = chart.viewport.max_price;
@@ -135,7 +137,9 @@ impl WebGpuRenderer {
         // Create instance data for each visible candle
         let step_size = 2.0 / visible_candles.len() as f32;
         let candle_width = (step_size * 0.8).clamp(MIN_ELEMENT_WIDTH, MAX_ELEMENT_WIDTH);
-        let mut instances = Vec::with_capacity(visible_candles.len());
+        let instances = Vec::with_capacity(visible_candles.len());
+
+        let half_width = candle_width * 0.5;
 
         for (i, candle) in visible_candles.iter().enumerate() {
             let x = candle_x_position(i, visible_candles.len());
@@ -259,8 +263,6 @@ impl WebGpuRenderer {
             ];
             vertices.extend_from_slice(&price_line);
         }
-
-        let vertices: Vec<CandleVertex> = BASE_TEMPLATE.to_vec();
 
         // Identity matrix - vertices are already in NDC coordinates [-1, 1]
         let view_proj_matrix = [

--- a/src/infrastructure/rendering/renderer/initialization.rs
+++ b/src/infrastructure/rendering/renderer/initialization.rs
@@ -119,9 +119,7 @@ impl WebGpuRenderer {
         let uniform_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("Uniform Buffer"),
             contents: bytemuck::cast_slice(&[ChartUniforms::new()]),
-            usage: wgpu::BufferUsages::UNIFORM
-                | wgpu::BufferUsages::COPY_DST
-                | wgpu::BufferUsages::MAP_WRITE,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
         });
 
         let uniform_bind_group_layout =
@@ -201,18 +199,14 @@ impl WebGpuRenderer {
         let vertex_buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("Vertex Buffer"),
             size: (std::mem::size_of::<CandleVertex>() * 100000) as u64,
-            usage: wgpu::BufferUsages::VERTEX
-                | wgpu::BufferUsages::COPY_DST
-                | wgpu::BufferUsages::MAP_WRITE,
+            usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });
 
         let instance_buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("Instance Buffer"),
             size: (std::mem::size_of::<CandleInstance>() * 100000) as u64,
-            usage: wgpu::BufferUsages::VERTEX
-                | wgpu::BufferUsages::COPY_DST
-                | wgpu::BufferUsages::MAP_WRITE,
+            usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });
 


### PR DESCRIPTION
## Summary
- create vertex and uniform buffers without MAP_WRITE
- clean WebGPU buffer writer
- ensure geometry builder defines temporary vectors

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684c1b0507708331887be015182387a9