### PR TITLE
Fix negative price during zoom

### DIFF
--- a/src/domain/chart/value_objects.rs
+++ b/src/domain/chart/value_objects.rs
@@ -81,6 +81,12 @@ impl Viewport {
 
         self.min_price = center_price - new_range / 2.0;
         self.max_price = center_price + new_range / 2.0;
+
+        if self.min_price < 0.1 {
+            let shift = 0.1 - self.min_price;
+            self.min_price += shift;
+            self.max_price += shift;
+        }
     }
 
     pub fn pan(&mut self, delta_x: f32, delta_y: f32) {

--- a/tests/zoom_price.rs
+++ b/tests/zoom_price.rs
@@ -1,0 +1,19 @@
+use price_chart_wasm::domain::chart::value_objects::Viewport;
+use wasm_bindgen_test::*;
+
+#[wasm_bindgen_test]
+fn zoom_price_not_negative() {
+    let mut vp = Viewport {
+        start_time: 0.0,
+        end_time: 100.0,
+        min_price: 10.0,
+        max_price: 20.0,
+        width: 800,
+        height: 600,
+    };
+
+    for _ in 0..3 {
+        vp.zoom_price(1.1, 1.0);
+    }
+    assert!(vp.min_price >= 0.1);
+}


### PR DESCRIPTION
## Summary
- clamp `min_price` when zooming by price to avoid negative range
- test vertical zoom clamping

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684c4bc516688331a396dbfebafc2677