### PR TITLE
Set default candle count to 100

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -33,7 +33,7 @@ use crate::{
 };
 
 /// Maximum number of candles visible at 1x zoom
-const MAX_VISIBLE_CANDLES: f64 = 300.0;
+const MAX_VISIBLE_CANDLES: f64 = 100.0;
 
 /// Minimum allowed zoom level
 const MIN_ZOOM_LEVEL: f64 = 0.5;

--- a/src/infrastructure/rendering/renderer/geometry.rs
+++ b/src/infrastructure/rendering/renderer/geometry.rs
@@ -4,7 +4,7 @@ use crate::infrastructure::rendering::gpu_structures::CandleInstance;
 use leptos::SignalGetUntracked;
 
 /// Base number of grid cells
-pub const BASE_CANDLES: f32 = 300.0;
+pub const BASE_CANDLES: f32 = 100.0;
 
 /// Template of 18 vertices for one candle (body + upper and lower wick)
 pub const BASE_TEMPLATE: [CandleVertex; 18] = [

--- a/tests/pan_viewport.rs
+++ b/tests/pan_viewport.rs
@@ -30,5 +30,5 @@ fn range_uses_viewport_start_time() {
 
     let (start, count) = visible_range_by_time(&candles, &vp, 1.0);
     assert_eq!(start, 50);
-    assert_eq!(count, 300);
+    assert_eq!(count, 100);
 }

--- a/tests/visible_range.rs
+++ b/tests/visible_range.rs
@@ -2,12 +2,12 @@ use price_chart_wasm::app::visible_range;
 
 #[test]
 fn visible_range_basic() {
-    assert_eq!(visible_range(1000, 1.0, 0.0), (700, 300));
+    assert_eq!(visible_range(1000, 1.0, 0.0), (900, 100));
     assert_eq!(visible_range(50, 2.0, 0.0), (0, 50));
 }
 
 #[test]
 fn visible_range_with_pan() {
-    assert_eq!(visible_range(1000, 1.0, -50.0), (650, 300));
+    assert_eq!(visible_range(1000, 1.0, -50.0), (850, 100));
     assert_eq!(visible_range(100, 1.0, -200.0), (0, 100));
 }


### PR DESCRIPTION
## Summary
- decrease MAX_VISIBLE_CANDLES to 100
- update BASE_CANDLES constant
- adjust tests for new visible range

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684c6071e51c8331a965c63e3018cc53