### PR TITLE
Skip GPU memory test when WebGPU unavailable

### DIFF
--- a/tests/gpu_memory.rs
+++ b/tests/gpu_memory.rs
@@ -20,6 +20,10 @@ fn setup_canvas(id: &str) {
 
 #[wasm_bindgen_test(async)]
 async fn memory_usage_returns_string() {
+    if !WebGpuRenderer::is_webgpu_supported().await {
+        web_sys::console::log_1(&"Skipping test: WebGPU not supported".into());
+        return;
+    }
     setup_canvas("mem-canvas");
     let renderer = WebGpuRenderer::new("mem-canvas", 10, 10).await.unwrap();
     let stats = renderer.log_gpu_memory_usage();


### PR DESCRIPTION
## Summary
- skip `memory_usage_returns_string` test when WebGPU isn't supported

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684cdf845f148331b1e23b96e9e407f2