### PR TITLE
Limit visible candles to 50

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -33,7 +33,7 @@ use crate::{
 };
 
 /// Maximum number of candles visible at 1x zoom
-const MAX_VISIBLE_CANDLES: f64 = 100.0;
+const MAX_VISIBLE_CANDLES: f64 = 50.0;
 
 /// Minimum allowed zoom level
 const MIN_ZOOM_LEVEL: f64 = 0.5;

--- a/tests/pan_viewport.rs
+++ b/tests/pan_viewport.rs
@@ -30,5 +30,5 @@ fn range_uses_viewport_start_time() {
 
     let (start, count) = visible_range_by_time(&candles, &vp, 1.0);
     assert_eq!(start, 50);
-    assert_eq!(count, 100);
+    assert_eq!(count, 50);
 }

--- a/tests/visible_range.rs
+++ b/tests/visible_range.rs
@@ -2,12 +2,12 @@ use price_chart_wasm::app::visible_range;
 
 #[test]
 fn visible_range_basic() {
-    assert_eq!(visible_range(1000, 1.0, 0.0), (900, 100));
-    assert_eq!(visible_range(50, 2.0, 0.0), (0, 50));
+    assert_eq!(visible_range(1000, 1.0, 0.0), (950, 50));
+    assert_eq!(visible_range(50, 2.0, 0.0), (25, 25));
 }
 
 #[test]
 fn visible_range_with_pan() {
-    assert_eq!(visible_range(1000, 1.0, -50.0), (850, 100));
-    assert_eq!(visible_range(100, 1.0, -200.0), (0, 100));
+    assert_eq!(visible_range(1000, 1.0, -50.0), (900, 50));
+    assert_eq!(visible_range(100, 1.0, -200.0), (0, 50));
 }


### PR DESCRIPTION
## Summary
- adjust constant to display 50 candles at 1x zoom
- update range calculations in tests

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`
- `cargo test --no-run`


------
https://chatgpt.com/codex/tasks/task_e_684d1b12163c8331adb04ef52d07d22b