### PR TITLE
Add axis synchronization tests

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1188,6 +1188,7 @@ async fn start_websocket_stream(chart: RwSignal<Chart>, set_status: WriteSignal<
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::chart::value_objects::ChartType;
     use wasm_bindgen::JsCast;
     use wasm_bindgen_test::*;
 
@@ -1216,7 +1217,8 @@ mod tests {
     #[wasm_bindgen_test]
     fn timeframe_buttons_update_interval() {
         let container = setup_container();
-        leptos::mount_to(container.clone(), || view! { <TimeframeSelector/> });
+        let chart = create_rw_signal(Chart::new("test".to_string(), ChartType::Candlestick, 100));
+        leptos::mount_to(container.clone(), move || view! { <TimeframeSelector chart=chart /> });
 
         let five = find_button(&container, "5m");
         five.click();

--- a/tests/axis_zoom.rs
+++ b/tests/axis_zoom.rs
@@ -1,0 +1,66 @@
+use price_chart_wasm::app::{price_levels, visible_range, visible_range_by_time};
+use price_chart_wasm::domain::chart::value_objects::Viewport;
+use price_chart_wasm::domain::market_data::{Candle, OHLCV, Price, Timestamp, Volume};
+use wasm_bindgen_test::*;
+
+fn make_candle(i: u64) -> Candle {
+    Candle::new(
+        Timestamp::from_millis(i * 60_000),
+        OHLCV::new(
+            Price::from(1.0),
+            Price::from(1.0),
+            Price::from(1.0),
+            Price::from(1.0),
+            Volume::from(1.0),
+        ),
+    )
+}
+
+#[wasm_bindgen_test]
+fn price_levels_change_after_zoom() {
+    let mut vp = Viewport {
+        start_time: 0.0,
+        end_time: 100.0,
+        min_price: 0.0,
+        max_price: 100.0,
+        width: 800,
+        height: 600,
+    };
+
+    let before = price_levels(&vp);
+    vp.zoom_price(2.0, 0.5);
+    let after = price_levels(&vp);
+
+    assert_ne!(before, after);
+    assert!((after[0] - 75.0).abs() < 1e-6);
+    assert!((after[8] - 25.0).abs() < 1e-6);
+}
+
+#[wasm_bindgen_test]
+fn time_axis_respects_zoom() {
+    let candles: Vec<Candle> = (0..100).map(make_candle).collect();
+    let mut vp = Viewport {
+        start_time: 0.0,
+        end_time: 100.0 * 60_000.0,
+        min_price: 0.0,
+        max_price: 1.0,
+        width: 800,
+        height: 600,
+    };
+
+    let (start_before, count_before) = visible_range_by_time(&candles, &vp, 1.0);
+    assert_eq!(start_before, 0);
+    assert_eq!(count_before, 50);
+
+    vp.zoom(2.0, 0.5);
+    let (start_after, count_after) = visible_range_by_time(&candles, &vp, 2.0);
+    assert_eq!(start_after, 25);
+    assert_eq!(count_after, 25);
+}
+
+#[test]
+fn visible_range_updates_with_new_candles() {
+    assert_eq!(visible_range(60, 1.0, 0.0), (10, 50));
+    assert_eq!(visible_range(70, 1.0, 0.0), (20, 50));
+    assert_eq!(visible_range(70, 2.0, 0.0), (45, 25));
+}


### PR DESCRIPTION
## Summary
- extend PriceAxis tests to cover zoom
- add tests for time axis with zoom and candle updates
- fix missing chart property in `TimeframeSelector` test module

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684d217941ec833189cf92b4e719d8ae