### PR TITLE
Add axis zoom test

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1188,6 +1188,7 @@ async fn start_websocket_stream(chart: RwSignal<Chart>, set_status: WriteSignal<
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::chart::{Chart, ChartType};
     use wasm_bindgen::JsCast;
     use wasm_bindgen_test::*;
 
@@ -1216,7 +1217,12 @@ mod tests {
     #[wasm_bindgen_test]
     fn timeframe_buttons_update_interval() {
         let container = setup_container();
-        leptos::mount_to(container.clone(), || view! { <TimeframeSelector/> });
+        let chart = create_rw_signal(Chart::new(
+            "test".to_string(),
+            ChartType::Candlestick,
+            10,
+        ));
+        leptos::mount_to(container.clone(), move || view! { <TimeframeSelector chart=chart /> });
 
         let five = find_button(&container, "5m");
         five.click();

--- a/tests/README.md
+++ b/tests/README.md
@@ -47,6 +47,10 @@ Regression tests:
 - `viewport_bounds_regression()` - viewport bounds
 - `spacing_uniformity_regression()` - spacing uniformity
 
+### `tests/axis_zoom.rs` - New
+Axis zoom test:
+- `price_levels_change_after_zoom()` - price levels follow zoomed range
+
 ## Running Tests
 
 Before running the suite ensure the WebAssembly target is installed:

--- a/tests/axis_zoom.rs
+++ b/tests/axis_zoom.rs
@@ -1,0 +1,23 @@
+use price_chart_wasm::app::price_levels;
+use price_chart_wasm::domain::chart::value_objects::Viewport;
+use wasm_bindgen_test::*;
+
+#[wasm_bindgen_test]
+fn price_levels_change_after_zoom() {
+    let mut vp = Viewport {
+        start_time: 0.0,
+        end_time: 100.0,
+        min_price: 0.0,
+        max_price: 100.0,
+        width: 800,
+        height: 600,
+    };
+
+    let original = price_levels(&vp);
+    vp.zoom_price(2.0, 0.5);
+    let zoomed = price_levels(&vp);
+
+    assert_ne!(original, zoomed);
+    assert!((zoomed[0] - 75.0).abs() < 1e-6);
+    assert!((zoomed[8] - 25.0).abs() < 1e-6);
+}


### PR DESCRIPTION
## Summary
- test price level update after zooming vertically
- document axis zoom test in chart positioning guide
- fix `timeframe_buttons_update_interval` test compilation

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684d27abb6788331b2fbbb399219a4a4