### PR TITLE
Add time scale sync test

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -47,6 +47,10 @@ Regression tests:
 - `viewport_bounds_regression()` - viewport bounds
 - `spacing_uniformity_regression()` - spacing uniformity
 
+### `tests/time_scale_sync.rs` - New
+Time scale logic tests:
+- `time_scale_updates_on_zoom_and_pan()` - labels follow zoom and pan
+
 ## Running Tests
 
 Before running the suite ensure the WebAssembly target is installed:

--- a/tests/time_scale_sync.rs
+++ b/tests/time_scale_sync.rs
@@ -1,0 +1,76 @@
+use price_chart_wasm::app::{visible_range, visible_range_by_time};
+use price_chart_wasm::domain::chart::{Chart, value_objects::ChartType};
+use price_chart_wasm::domain::market_data::{
+    Candle, OHLCV, Price, TimeInterval, Timestamp, Volume,
+};
+use wasm_bindgen::JsValue;
+use wasm_bindgen_test::*;
+
+fn make_candle(i: u64) -> Candle {
+    Candle::new(
+        Timestamp::from_millis(i * 60_000),
+        OHLCV::new(
+            Price::from(1.0),
+            Price::from(1.0),
+            Price::from(1.0),
+            Price::from(1.0),
+            Volume::from(1.0),
+        ),
+    )
+}
+
+fn time_labels(chart: &Chart, zoom: f64) -> Vec<String> {
+    let interval = TimeInterval::OneMinute;
+    let candles = chart.get_series(interval).unwrap().get_candles();
+    if candles.is_empty() {
+        return vec![];
+    }
+
+    let candle_vec: Vec<_> = candles.iter().cloned().collect();
+    let (start_idx, visible) = visible_range_by_time(&candle_vec, &chart.viewport, zoom);
+    let base_start = candle_vec.len().saturating_sub(visible);
+    let pan = start_idx as isize - base_start as isize;
+    let (start_idx, visible) = visible_range(candle_vec.len(), zoom, pan as f64);
+
+    let num_labels = 5;
+    let mut labels = Vec::new();
+    for i in 0..num_labels {
+        let index = (i * visible) / (num_labels - 1);
+        if let Some(candle) =
+            candle_vec.iter().skip(start_idx).nth(index.min(visible.saturating_sub(1)))
+        {
+            let ts = candle.timestamp.value();
+            let date = js_sys::Date::new(&JsValue::from_f64(ts as f64));
+            let label = if zoom >= 2.0 {
+                format!("{:02}:{:02}", date.get_hours(), date.get_minutes())
+            } else if zoom >= 1.0 {
+                format!("{:02}.{:02}", date.get_date(), date.get_month() + 1)
+            } else {
+                format!("{:02}.{}", date.get_month() + 1, date.get_full_year())
+            };
+            labels.push(label);
+        }
+    }
+    labels
+}
+
+#[wasm_bindgen_test]
+fn time_scale_updates_on_zoom_and_pan() {
+    let candles: Vec<Candle> = (0..120).map(make_candle).collect();
+    let mut chart = Chart::new("test".to_string(), ChartType::Candlestick, 200);
+    chart.set_historical_data(candles);
+
+    let mut zoom = 1.0f64;
+
+    let labels_before = time_labels(&chart, zoom);
+
+    chart.zoom(2.0, 0.5);
+    zoom *= 2.0;
+    let labels_after_zoom = time_labels(&chart, zoom);
+    assert_ne!(labels_before, labels_after_zoom);
+
+    chart.pan(-0.1, 0.0);
+    let labels_after_pan = time_labels(&chart, zoom);
+    assert_ne!(labels_after_zoom, labels_after_pan);
+    assert_eq!(labels_after_pan.len(), 5);
+}


### PR DESCRIPTION
## Summary
- add new integration test for time scale label updates
- document this test in `tests/README.md`

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684d33c02cd083319126411a665617cb