### PR TITLE
Add edge check for current price line

### DIFF
--- a/tests/indicator_vertices.rs
+++ b/tests/indicator_vertices.rs
@@ -8,6 +8,8 @@ fn current_price_line_vertices() {
     assert!((verts[0].position_x + 1.0).abs() < f32::EPSILON);
     assert!((verts[0].position_y - 0.4).abs() < f32::EPSILON);
     assert!((verts[0].color_type - 7.0).abs() < f32::EPSILON);
+    let last = verts.last().unwrap();
+    assert!((last.position_x - 1.0).abs() < f32::EPSILON);
 }
 
 #[wasm_bindgen_test]


### PR DESCRIPTION
## Summary
- verify last vertex of current price line reaches right border

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684d41f7f4bc8331ae3206b0e9ed9476