### PR TITLE
Remove wasm-tools coverage steps

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,8 +23,6 @@ jobs:
         run: cargo install wasm-tools
       - name: Run tests
         run: wasm-pack test --headless --chrome
-      - name: Generate lcov
-        run: wasm-tools coverage target/wasm32-unknown-unknown/debug/deps/*.wasm > lcov.info
       - name: Install cargo-llvm-cov
         run: cargo install cargo-llvm-cov
       - name: Generate coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,10 @@ jobs:
         run: cargo clippy --all-targets --all-features -- -D warnings || echo 'Clippy warnings found'
       - name: Run tests
         run: wasm-pack test --headless --chrome
-      - name: Generate lcov
-        run: wasm-tools coverage target/wasm32-unknown-unknown/debug/deps/*.wasm > lcov.info
+      - name: Install cargo-llvm-cov
+        run: cargo install cargo-llvm-cov
+      - name: Generate coverage
+        run: cargo llvm-cov --workspace --lcov --output-path lcov.info
       - name: Upload coverage
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- adjust coverage workflow to rely on `cargo llvm-cov`
- generate coverage with `cargo llvm-cov` in test workflow

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`

------
https://chatgpt.com/codex/tasks/task_e_684d4780e65883319c91a9063dcc12ca