### PR TITLE
Add FPS parsing

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -18,7 +18,8 @@ jobs:
           python-version: '3.x'
       - name: Run benchmarks
         run: |
-          echo '{"fps": 60}' > benchmark_result.json
+          wasm-pack test --headless --chrome -- --nocapture | tee perf.log
+          python scripts/parse_perf_log.py perf.log benchmark_result.json
       - name: Analyze FPS
         run: |
           python scripts/compare_fps.py benchmark_result.json docs/perf_baseline.json docs/perf_result.json 5

--- a/scripts/parse_perf_log.py
+++ b/scripts/parse_perf_log.py
@@ -1,0 +1,21 @@
+import json
+import re
+import sys
+
+if len(sys.argv) != 3:
+    print("Usage: parse_perf_log.py LOG OUTPUT")
+    sys.exit(1)
+
+log_path, out_path = sys.argv[1:3]
+
+fps_values = []
+with open(log_path) as f:
+    for line in f:
+        m = re.search(r"\d+ candles: ([0-9.]+) FPS", line)
+        if m:
+            fps_values.append(float(m.group(1)))
+
+fps = sum(fps_values) / len(fps_values) if fps_values else 0.0
+
+with open(out_path, "w") as f:
+    json.dump({"fps": fps}, f)


### PR DESCRIPTION
## Summary
- parse perf log for FPS
- run benchmark tests in workflow

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`

------
https://chatgpt.com/codex/tasks/task_e_684d477aebd4833186f5f72c941eba59