### PR TITLE
Fix current price line vertices

### DIFF
--- a/src/infrastructure/rendering/gpu_structures.rs
+++ b/src/infrastructure/rendering/gpu_structures.rs
@@ -366,9 +366,9 @@ impl CandleGeometry {
             CandleVertex::current_price_vertex(-1.0, current_price_y - half_width),
             CandleVertex::current_price_vertex(1.0, current_price_y - half_width),
             CandleVertex::current_price_vertex(-1.0, current_price_y + half_width),
+            CandleVertex::current_price_vertex(-1.0, current_price_y + half_width),
             CandleVertex::current_price_vertex(1.0, current_price_y - half_width),
             CandleVertex::current_price_vertex(1.0, current_price_y + half_width),
-            CandleVertex::current_price_vertex(-1.0, current_price_y + half_width),
         ]
     }
 


### PR DESCRIPTION
## Summary
- ensure the last vertex of the current price line has `x = 1.0`

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684d4e4c437c8331878795d1d09bd876