### PR TITLE
Add viewport data clamp

### DIFF
--- a/src/domain/chart/entities.rs
+++ b/src/domain/chart/entities.rs
@@ -115,6 +115,11 @@ impl Chart {
 
     pub fn zoom(&mut self, factor: f32, center_x: f32) {
         self.viewport.zoom(factor, center_x);
+        if let Some(series) = self.series.get(&TimeInterval::OneMinute) {
+            if let Some((first, last)) = series.time_bounds() {
+                self.viewport.clamp_to_data(first, last);
+            }
+        }
     }
 
     /// Vertical zoom by price
@@ -124,6 +129,11 @@ impl Chart {
 
     pub fn pan(&mut self, delta_x: f32, delta_y: f32) {
         self.viewport.pan(delta_x, delta_y);
+        if let Some(series) = self.series.get(&TimeInterval::OneMinute) {
+            if let Some((first, last)) = series.time_bounds() {
+                self.viewport.clamp_to_data(first, last);
+            }
+        }
     }
 
     pub fn get_series(&self, interval: TimeInterval) -> Option<&CandleSeries> {

--- a/src/domain/chart/value_objects.rs
+++ b/src/domain/chart/value_objects.rs
@@ -99,6 +99,34 @@ impl Viewport {
         self.max_price += price_delta;
     }
 
+    /// Keep the viewport within available candle data
+    pub fn clamp_to_data(&mut self, first_ts: u64, last_ts: u64) {
+        if first_ts >= last_ts {
+            self.start_time = first_ts as f64;
+            self.end_time = last_ts as f64;
+            return;
+        }
+
+        let range = self.time_range();
+
+        self.start_time = self.start_time.max(first_ts as f64);
+        self.end_time = self.start_time + range;
+
+        if self.end_time > last_ts as f64 {
+            self.end_time = last_ts as f64;
+            self.start_time = self.end_time - range;
+
+            if self.start_time < first_ts as f64 {
+                self.start_time = first_ts as f64;
+            }
+        }
+
+        if range > (last_ts - first_ts) as f64 {
+            self.start_time = first_ts as f64;
+            self.end_time = last_ts as f64;
+        }
+    }
+
     /// Convert a timestamp to a screen X coordinate
     pub fn time_to_x(&self, timestamp: f64) -> f32 {
         if self.time_range() == 0.0 {

--- a/src/domain/market_data/entities.rs
+++ b/src/domain/market_data/entities.rs
@@ -145,4 +145,14 @@ impl CandleSeries {
 
         Some((min_price, max_price))
     }
+
+    /// Get timestamps of the first and last candles
+    pub fn time_bounds(&self) -> Option<(u64, u64)> {
+        if self.candles.is_empty() {
+            return None;
+        }
+        let first = self.candles.front().unwrap().timestamp.value();
+        let last = self.candles.back().unwrap().timestamp.value();
+        Some((first, last))
+    }
 }

--- a/tests/viewport_clamp.rs
+++ b/tests/viewport_clamp.rs
@@ -1,0 +1,29 @@
+use price_chart_wasm::domain::chart::{Chart, value_objects::ChartType};
+use price_chart_wasm::domain::market_data::{Candle, OHLCV, Price, Timestamp, Volume};
+use wasm_bindgen_test::*;
+
+fn make_candle(i: u64) -> Candle {
+    Candle::new(
+        Timestamp::from_millis(i * 60_000),
+        OHLCV::new(
+            Price::from(1.0),
+            Price::from(1.0),
+            Price::from(1.0),
+            Price::from(1.0),
+            Volume::from(1.0),
+        ),
+    )
+}
+
+#[wasm_bindgen_test]
+fn viewport_clamped_to_data() {
+    let candles: Vec<Candle> = (0..5).map(make_candle).collect();
+    let mut chart = Chart::new("test".into(), ChartType::Candlestick, 100);
+    chart.set_historical_data(candles);
+
+    chart.zoom(0.5, 1.0);
+    chart.pan(1.0, 0.0);
+
+    let last_ts = 4 * 60_000u64;
+    assert!((chart.viewport.end_time - last_ts as f64).abs() < f64::EPSILON);
+}


### PR DESCRIPTION
## Summary
- keep viewport within candle range
- expose candle time bounds
- clamp Chart pan/zoom
- test viewport clamping
- refine viewport clamping logic

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684d4e2bcfa083319581c3af1afb518b