### PR TITLE
Fix wasm coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,7 +15,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly
           targets: wasm32-unknown-unknown
       - name: Install wasm-pack
         run: cargo install wasm-pack
@@ -26,7 +26,7 @@ jobs:
       - name: Install cargo-llvm-cov
         run: cargo install cargo-llvm-cov
       - name: Generate coverage
-        run: cargo llvm-cov --workspace --lcov --output-path lcov.info
+        run: cargo llvm-cov --workspace --lcov --output-path lcov.info --target wasm32-unknown-unknown -Z build-std=std,panic_abort,profiler_builtins
       - name: Compute coverage
         run: |
           python - <<'PY'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly
           targets: wasm32-unknown-unknown
       - name: Install rustup if needed
         run: |
@@ -31,7 +31,7 @@ jobs:
       - name: Install cargo-llvm-cov
         run: cargo install cargo-llvm-cov
       - name: Generate coverage
-        run: cargo llvm-cov --workspace --lcov --output-path lcov.info
+        run: cargo llvm-cov --workspace --lcov --output-path lcov.info --target wasm32-unknown-unknown -Z build-std=std,panic_abort,profiler_builtins
       - name: Upload coverage
         uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ See [TESTS.md](DOCS/TESTS.md) for more details about the test suite.
 Coverage can be collected with `cargo-llvm-cov`:
 
 ```bash
-cargo llvm-cov --workspace --lcov --output-path lcov.info
+cargo llvm-cov --workspace --lcov --output-path lcov.info --target wasm32-unknown-unknown -Z build-std=std,panic_abort,profiler_builtins
 ```
 
 The generated `lcov.info` file can be uploaded by CI.


### PR DESCRIPTION
## Summary
- switch GitHub Actions workflows to nightly toolchain
- build Rust stdlib for wasm to enable coverage
- document the updated coverage command

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684d55a126ac8331800a66cd2676846a