### PR TITLE
fix compare_fps absence handling

### DIFF
--- a/scripts/compare_fps.py
+++ b/scripts/compare_fps.py
@@ -9,9 +9,16 @@ if len(sys.argv) != 5:
 new_file, baseline_file, output_file, threshold = sys.argv[1:]
 threshold = float(threshold)
 
+if not os.path.exists(new_file):
+    print("benchmark_result.json not found, run parse_perf_log.py first")
+    sys.exit(1)
+
 with open(new_file) as f:
     new_data = json.load(f)
 new_fps = float(new_data.get("fps", 0))
+
+if new_fps == 0:
+    print("Warning: FPS is zero, logs might be incorrect")
 
 if os.path.exists(baseline_file):
     with open(baseline_file) as f:

--- a/tests/compare_fps_script.py
+++ b/tests/compare_fps_script.py
@@ -1,0 +1,17 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_missing_file(tmp_path):
+    missing = tmp_path / "benchmark_result.json"
+    baseline = tmp_path / "baseline.json"
+    output = tmp_path / "result.json"
+    result = subprocess.run(
+        [sys.executable, str(Path(__file__).resolve().parent.parent / "scripts" / "compare_fps.py"),
+         str(missing), str(baseline), str(output), "5"],
+        capture_output=True, text=True
+    )
+    assert result.returncode == 1
+    assert "benchmark_result.json not found" in result.stdout
+


### PR DESCRIPTION
## Summary
- abort when `benchmark_result.json` is missing
- warn when FPS equals zero
- test script behavior for missing file

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`
- `pytest -q tests/compare_fps_script.py`


------
https://chatgpt.com/codex/tasks/task_e_684d5ad3e0648331893cb0054ec4a612