### PR TITLE
Recalculate candle width

### DIFF
--- a/src/infrastructure/rendering/renderer/geometry.rs
+++ b/src/infrastructure/rendering/renderer/geometry.rs
@@ -35,6 +35,8 @@ pub const BASE_TEMPLATE: [CandleVertex; 18] = [
 pub const MIN_ELEMENT_WIDTH: f32 = 0.002;
 /// Maximum element width (candle or volume bar)
 pub const MAX_ELEMENT_WIDTH: f32 = 0.1;
+/// Ratio of space left empty between elements
+pub const SPACING_RATIO: f32 = 0.2;
 
 /// Candle/bar position taking right edge into account
 pub fn candle_x_position(index: usize, visible_len: usize) -> f32 {
@@ -97,16 +99,14 @@ impl WebGpuRenderer {
         max_price += price_range * 0.05;
 
         // Calculate visible candle width and spacing
-        let spacing_ratio = 0.2; // 20% spacing between candles
         let step_size = chart_width / candle_count as f64;
-        let max_candle_width = step_size * (1.0 - spacing_ratio);
-        let _candle_width = max_candle_width.clamp(0.01, 0.06); // Reasonable width limits
+        let candle_width_estimate = step_size * (1.0 - SPACING_RATIO as f64);
 
         get_logger().info(
             LogComponent::Infrastructure("WebGpuRenderer"),
             &format!(
                 "📏 Price range: {:.2} - {:.2}, Candle width: {:.4}, step:{:.4}",
-                min_price, max_price, _candle_width, step_size
+                min_price, max_price, candle_width_estimate, step_size
             ),
         );
 
@@ -133,7 +133,7 @@ impl WebGpuRenderer {
 
         // Create instance data for each visible candle
         let step_size = 2.0 / visible_candles.len() as f32;
-        let candle_width = (step_size * 0.8).clamp(MIN_ELEMENT_WIDTH, MAX_ELEMENT_WIDTH);
+        let candle_width = (step_size * (1.0 - SPACING_RATIO)).max(MIN_ELEMENT_WIDTH);
         let mut instances = Vec::with_capacity(visible_candles.len());
 
         let half_width = candle_width * 0.5;
@@ -294,7 +294,7 @@ impl WebGpuRenderer {
             ema12_color: [0.8, 0.2, 0.8, 0.9],         // purple
             ema26_color: [0.0, 0.8, 0.8, 0.9],         // cyan
             current_price_color: [1.0, 1.0, 0.0, 0.8], // 💰 bright yellow
-            render_params: [candle_width, spacing_ratio as f32, 0.004, 0.0],
+            render_params: [candle_width, SPACING_RATIO, 0.004, 0.0],
         };
 
         (instances, vertices, uniforms)

--- a/src/infrastructure/rendering/renderer/mod.rs
+++ b/src/infrastructure/rendering/renderer/mod.rs
@@ -101,7 +101,8 @@ impl Default for LineVisibility {
 
 mod geometry;
 pub use geometry::{
-    BASE_CANDLES, BASE_TEMPLATE, MAX_ELEMENT_WIDTH, MIN_ELEMENT_WIDTH, candle_x_position,
+    BASE_CANDLES, BASE_TEMPLATE, MAX_ELEMENT_WIDTH, MIN_ELEMENT_WIDTH, SPACING_RATIO,
+    candle_x_position,
 };
 mod initialization;
 mod performance;

--- a/tests/volume_candle_sync.rs
+++ b/tests/volume_candle_sync.rs
@@ -1,6 +1,6 @@
 use price_chart_wasm::domain::market_data::{Candle, OHLCV, Price, Timestamp, Volume};
 use price_chart_wasm::infrastructure::rendering::renderer::{
-    MAX_ELEMENT_WIDTH, MIN_ELEMENT_WIDTH, candle_x_position,
+    MIN_ELEMENT_WIDTH, SPACING_RATIO, candle_x_position,
 };
 use wasm_bindgen_test::*;
 
@@ -61,7 +61,7 @@ fn volume_width_sync() {
 
     // Check that step_size is the same for candles and volume bars
     let step_size = 2.0 / visible_len as f32;
-    let expected_width = (step_size * 0.8).clamp(MIN_ELEMENT_WIDTH, MAX_ELEMENT_WIDTH);
+    let expected_width = (step_size * (1.0 - SPACING_RATIO)).max(MIN_ELEMENT_WIDTH);
 
     // Emulate logic from the code
     for i in 0..visible_len {

--- a/tests/width_sync_test.rs
+++ b/tests/width_sync_test.rs
@@ -1,5 +1,5 @@
 use price_chart_wasm::infrastructure::rendering::renderer::{
-    MAX_ELEMENT_WIDTH, MIN_ELEMENT_WIDTH, candle_x_position,
+    MIN_ELEMENT_WIDTH, SPACING_RATIO, candle_x_position,
 };
 use wasm_bindgen_test::*;
 
@@ -10,10 +10,10 @@ fn width_calculation_sync() {
 
     // Emulate candle width logic
     let step_size = 2.0 / visible_len as f32;
-    let candle_width = (step_size * 0.8).clamp(MIN_ELEMENT_WIDTH, MAX_ELEMENT_WIDTH);
+    let candle_width = (step_size * (1.0 - SPACING_RATIO)).max(MIN_ELEMENT_WIDTH);
 
     // Emulate volume bar logic (after fix)
-    let bar_width = (step_size * 0.8).clamp(MIN_ELEMENT_WIDTH, MAX_ELEMENT_WIDTH);
+    let bar_width = (step_size * (1.0 - SPACING_RATIO)).max(MIN_ELEMENT_WIDTH);
 
     // Verify the widths match
     assert_eq!(
@@ -24,7 +24,27 @@ fn width_calculation_sync() {
 
     // Ensure width stays within limits
     assert!(candle_width >= MIN_ELEMENT_WIDTH, "Width too small: {:.6}", candle_width);
-    assert!(candle_width <= MAX_ELEMENT_WIDTH, "Width too large: {:.6}", candle_width);
+    assert!(
+        candle_width <= step_size * (1.0 - SPACING_RATIO) + f32::EPSILON,
+        "Width exceeds expected maximum: {:.6}",
+        candle_width
+    );
+}
+
+#[wasm_bindgen_test]
+fn no_extra_gaps_small_range() {
+    // With few bars there should be no additional gaps due to clamping
+    let visible_len = 5;
+    let step_size = 2.0 / visible_len as f32;
+    let candle_width = (step_size * (1.0 - SPACING_RATIO)).max(MIN_ELEMENT_WIDTH);
+
+    // Expected gap equals spacing ratio portion of the step
+    let gap = step_size - candle_width;
+    assert!(
+        (gap - step_size * SPACING_RATIO).abs() < f32::EPSILON,
+        "Unexpected gap size: {:.6}",
+        gap
+    );
 }
 
 #[wasm_bindgen_test]


### PR DESCRIPTION
## Summary
- compute candle width using `SPACING_RATIO`
- export new `SPACING_RATIO` constant
- ensure no extra gaps for small chart ranges in tests

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`

------
https://chatgpt.com/codex/tasks/task_e_684d5ae8cf0883318c71cff1df875980