### PR TITLE
Set default candles to 32

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -33,7 +33,7 @@ use crate::{
 };
 
 /// Maximum number of candles visible at 1x zoom
-const MAX_VISIBLE_CANDLES: f64 = 50.0;
+const MAX_VISIBLE_CANDLES: f64 = 32.0;
 /// Minimum number of candles that must remain visible
 const MIN_VISIBLE_CANDLES: f64 = 20.0;
 

--- a/tests/axis_zoom.rs
+++ b/tests/axis_zoom.rs
@@ -50,17 +50,17 @@ fn time_axis_respects_zoom() {
 
     let (start_before, count_before) = visible_range_by_time(&candles, &vp, 1.0);
     assert_eq!(start_before, 0);
-    assert_eq!(count_before, 50);
+    assert_eq!(count_before, 32);
 
     vp.zoom(2.0, 0.5);
     let (start_after, count_after) = visible_range_by_time(&candles, &vp, 2.0);
     assert_eq!(start_after, 25);
-    assert_eq!(count_after, 25);
+    assert_eq!(count_after, 20);
 }
 
 #[test]
 fn visible_range_updates_with_new_candles() {
-    assert_eq!(visible_range(60, 1.0, 0.0), (10, 50));
-    assert_eq!(visible_range(70, 1.0, 0.0), (20, 50));
-    assert_eq!(visible_range(70, 2.0, 0.0), (45, 25));
+    assert_eq!(visible_range(60, 1.0, 0.0), (28, 32));
+    assert_eq!(visible_range(70, 1.0, 0.0), (38, 32));
+    assert_eq!(visible_range(70, 2.0, 0.0), (50, 20));
 }

--- a/tests/pan_viewport.rs
+++ b/tests/pan_viewport.rs
@@ -30,5 +30,5 @@ fn range_uses_viewport_start_time() {
 
     let (start, count) = visible_range_by_time(&candles, &vp, 1.0);
     assert_eq!(start, 50);
-    assert_eq!(count, 50);
+    assert_eq!(count, 32);
 }

--- a/tests/visible_range.rs
+++ b/tests/visible_range.rs
@@ -2,12 +2,12 @@ use price_chart_wasm::app::visible_range;
 
 #[test]
 fn visible_range_basic() {
-    assert_eq!(visible_range(1000, 1.0, 0.0), (950, 50));
-    assert_eq!(visible_range(50, 2.0, 0.0), (25, 25));
+    assert_eq!(visible_range(1000, 1.0, 0.0), (968, 32));
+    assert_eq!(visible_range(50, 2.0, 0.0), (30, 20));
 }
 
 #[test]
 fn visible_range_with_pan() {
-    assert_eq!(visible_range(1000, 1.0, -50.0), (900, 50));
-    assert_eq!(visible_range(100, 1.0, -200.0), (0, 50));
+    assert_eq!(visible_range(1000, 1.0, -50.0), (918, 32));
+    assert_eq!(visible_range(100, 1.0, -200.0), (0, 32));
 }


### PR DESCRIPTION
## Summary
- render 32 candles by default
- update axis zoom and visible range tests

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684d5688a6608331a7e8994fa6220ff4