### PR TITLE
Add candle color logic test

### DIFF
--- a/src/infrastructure/rendering/renderer/geometry.rs
+++ b/src/infrastructure/rendering/renderer/geometry.rs
@@ -418,6 +418,7 @@ mod tests {
                 cached_candle_count: 0,
                 cached_zoom_level: 1.0,
                 cached_hash: 0,
+                cached_data_hash: 0,
                 zoom_level: 1.0,
                 pan_offset: 0.0,
                 last_frame_time: 0.0,

--- a/tests/geometry.rs
+++ b/tests/geometry.rs
@@ -62,3 +62,16 @@ fn candle_geometry_snapshot() {
         assert_json_snapshot!("candle_vertices", result);
     });
 }
+
+#[wasm_bindgen_test]
+fn candle_color_logic() {
+    let bullish = CandleGeometry::create_candle_vertices(
+        0.0, 1.0, 1.2, 0.8, 1.1, 0.0, 0.0, 0.2, -0.2, 0.1, 0.2,
+    );
+    assert!((bullish[0].color_type - 1.0).abs() < f32::EPSILON);
+
+    let bearish = CandleGeometry::create_candle_vertices(
+        0.0, 1.1, 1.2, 0.9, 1.0, 0.0, 0.1, 0.2, -0.2, 0.0, 0.2,
+    );
+    assert!((bearish[0].color_type - 0.0).abs() < f32::EPSILON);
+}


### PR DESCRIPTION
## Summary
- test candle color type for bullish and bearish cases
- fix dummy renderer for cached_data_hash field

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`
- `cargo test --no-run`


------
https://chatgpt.com/codex/tasks/task_e_684d6e738c3c83318cfce1b2e574141b