### PR TITLE
Improve candle spacing

### DIFF
--- a/src/infrastructure/rendering/renderer/mod.rs
+++ b/src/infrastructure/rendering/renderer/mod.rs
@@ -103,7 +103,7 @@ impl Default for LineVisibility {
 mod geometry;
 pub use geometry::{
     BASE_CANDLES, BASE_TEMPLATE, MAX_ELEMENT_WIDTH, MIN_ELEMENT_WIDTH, SPACING_RATIO,
-    candle_x_position,
+    candle_x_position, spacing_ratio_for,
 };
 mod initialization;
 mod performance;

--- a/tests/dynamic_spacing.rs
+++ b/tests/dynamic_spacing.rs
@@ -1,0 +1,9 @@
+use price_chart_wasm::infrastructure::rendering::renderer::spacing_ratio_for;
+use wasm_bindgen_test::*;
+
+#[wasm_bindgen_test]
+fn spacing_decreases_on_zoom_in() {
+    let wide = spacing_ratio_for(100);
+    let zoomed = spacing_ratio_for(10);
+    assert!(zoomed < wide, "Spacing should decrease when fewer candles are visible");
+}

--- a/tests/width_sync_test.rs
+++ b/tests/width_sync_test.rs
@@ -1,5 +1,5 @@
 use price_chart_wasm::infrastructure::rendering::renderer::{
-    MIN_ELEMENT_WIDTH, SPACING_RATIO, candle_x_position,
+    MIN_ELEMENT_WIDTH, candle_x_position, spacing_ratio_for,
 };
 use wasm_bindgen_test::*;
 
@@ -10,10 +10,11 @@ fn width_calculation_sync() {
 
     // Emulate candle width logic
     let step_size = 2.0 / visible_len as f32;
-    let candle_width = (step_size * (1.0 - SPACING_RATIO)).max(MIN_ELEMENT_WIDTH);
+    let spacing = spacing_ratio_for(visible_len);
+    let candle_width = (step_size * (1.0 - spacing)).max(MIN_ELEMENT_WIDTH);
 
     // Emulate volume bar logic (after fix)
-    let bar_width = (step_size * (1.0 - SPACING_RATIO)).max(MIN_ELEMENT_WIDTH);
+    let bar_width = (step_size * (1.0 - spacing)).max(MIN_ELEMENT_WIDTH);
 
     // Verify the widths match
     assert_eq!(
@@ -25,7 +26,7 @@ fn width_calculation_sync() {
     // Ensure width stays within limits
     assert!(candle_width >= MIN_ELEMENT_WIDTH, "Width too small: {:.6}", candle_width);
     assert!(
-        candle_width <= step_size * (1.0 - SPACING_RATIO) + f32::EPSILON,
+        candle_width <= step_size * (1.0 - spacing) + f32::EPSILON,
         "Width exceeds expected maximum: {:.6}",
         candle_width
     );
@@ -36,15 +37,12 @@ fn no_extra_gaps_small_range() {
     // With few bars there should be no additional gaps due to clamping
     let visible_len = 5;
     let step_size = 2.0 / visible_len as f32;
-    let candle_width = (step_size * (1.0 - SPACING_RATIO)).max(MIN_ELEMENT_WIDTH);
+    let spacing = spacing_ratio_for(visible_len);
+    let candle_width = (step_size * (1.0 - spacing)).max(MIN_ELEMENT_WIDTH);
 
     // Expected gap equals spacing ratio portion of the step
     let gap = step_size - candle_width;
-    assert!(
-        (gap - step_size * SPACING_RATIO).abs() < f32::EPSILON,
-        "Unexpected gap size: {:.6}",
-        gap
-    );
+    assert!((gap - step_size * spacing).abs() < f32::EPSILON, "Unexpected gap size: {:.6}", gap);
 }
 
 #[wasm_bindgen_test]


### PR DESCRIPTION
## Summary
- add dynamic spacing ratio function for candle layout
- adjust geometry to use new spacing and clamp widths
- tweak wick width calculation
- export helper in renderer
- update width tests and add zoom test

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684d6da8aa0c833188f7c801472b6c85