### PR TITLE
Remove unused BASE_CANDLES constant

### DIFF
--- a/src/infrastructure/rendering/renderer/geometry.rs
+++ b/src/infrastructure/rendering/renderer/geometry.rs
@@ -7,9 +7,6 @@ use crate::infrastructure::rendering::gpu_structures::{
 };
 use leptos::SignalGetUntracked;
 
-/// Base number of grid cells
-pub const BASE_CANDLES: f32 = 100.0;
-
 /// Template of 18 vertices for one candle (body + upper and lower wick)
 pub const BASE_TEMPLATE: [CandleVertex; 18] = [
     // Body
@@ -44,7 +41,7 @@ pub const SPACING_RATIO: f32 = 0.2;
 
 /// Dynamic spacing based on number of visible candles
 pub fn spacing_ratio_for(visible_len: usize) -> f32 {
-    let factor = (visible_len as f32 / BASE_CANDLES).min(1.0);
+    let factor = (visible_len as f32 / 100.0).min(1.0);
     SPACING_RATIO * factor
 }
 

--- a/src/infrastructure/rendering/renderer/mod.rs
+++ b/src/infrastructure/rendering/renderer/mod.rs
@@ -102,8 +102,8 @@ impl Default for LineVisibility {
 
 mod geometry;
 pub use geometry::{
-    BASE_CANDLES, BASE_TEMPLATE, MAX_ELEMENT_WIDTH, MIN_ELEMENT_WIDTH, SPACING_RATIO,
-    candle_x_position, spacing_ratio_for,
+    BASE_TEMPLATE, MAX_ELEMENT_WIDTH, MIN_ELEMENT_WIDTH, SPACING_RATIO, candle_x_position,
+    spacing_ratio_for,
 };
 mod initialization;
 mod performance;


### PR DESCRIPTION
## Summary
- clean up renderer constants
- drop `BASE_CANDLES` and inline value in `spacing_ratio_for`

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`

------
https://chatgpt.com/codex/tasks/task_e_684d7345d60c8331af755f3283168885