### PR TITLE
Reduce min candle count to 1

### DIFF
--- a/DOCS/VOLUME_SYNC_FIXES.md
+++ b/DOCS/VOLUME_SYNC_FIXES.md
@@ -62,7 +62,7 @@ After the fixes:
 | **Right edge**  | ✅ x=1.0            | ✅ x=1.0               |
 
 ## 📊 Covered Scenarios
-- Various zoom levels (0.1x - 10.0x)
+- Various zoom levels (0.2x - 32x)
 - Different numbers of visible candles (1-300)
 - Positioning edge cases
 - Synchronization of all chart elements (candles, volume, grid, indicators)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # WebGPU Candles
 
 A demonstration Bitcoin candlestick chart built with **WebGPU** for rendering and **Leptos** for the reactive UI. Real-time price data is streamed from Binance via WebSocket and drawn directly to a `<canvas>` using Rust compiled to WebAssembly.
+The chart supports zoom levels from roughly `0.2x` up to `32x` with a minimum of one visible candle.
 The project requires the `wasm32-unknown-unknown` target, which the build script verifies is installed. Install it with:
 `rustup target add wasm32-unknown-unknown`.
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -35,12 +35,12 @@ use crate::{
 /// Maximum number of candles visible at 1x zoom
 const MAX_VISIBLE_CANDLES: f64 = 32.0;
 /// Minimum number of candles that must remain visible
-const MIN_VISIBLE_CANDLES: f64 = 20.0;
+const MIN_VISIBLE_CANDLES: f64 = 1.0;
 
 /// Minimum allowed zoom level
 const MIN_ZOOM_LEVEL: f64 = MAX_VISIBLE_CANDLES / 150.0;
 /// Maximum allowed zoom level
-const MAX_ZOOM_LEVEL: f64 = MAX_VISIBLE_CANDLES / MIN_VISIBLE_CANDLES;
+const MAX_ZOOM_LEVEL: f64 = 32.0;
 
 /// Pan offset required to trigger history loading
 pub const HISTORY_FETCH_THRESHOLD: f64 = -50.0;
@@ -1242,6 +1242,6 @@ mod tests {
         assert!(visible_min_zoom <= 150);
 
         let (_, visible_max_zoom) = visible_range(1000, MAX_ZOOM_LEVEL, 0.0);
-        assert!(visible_max_zoom >= 20);
+        assert!(visible_max_zoom as f64 >= MIN_VISIBLE_CANDLES);
     }
 }

--- a/src/infrastructure/rendering/renderer/geometry.rs
+++ b/src/infrastructure/rendering/renderer/geometry.rs
@@ -418,6 +418,7 @@ mod tests {
                 cached_candle_count: 0,
                 cached_zoom_level: 1.0,
                 cached_hash: 0,
+                cached_data_hash: 0,
                 zoom_level: 1.0,
                 pan_offset: 0.0,
                 last_frame_time: 0.0,

--- a/tests/axis_zoom.rs
+++ b/tests/axis_zoom.rs
@@ -55,12 +55,12 @@ fn time_axis_respects_zoom() {
     vp.zoom(2.0, 0.5);
     let (start_after, count_after) = visible_range_by_time(&candles, &vp, 2.0);
     assert_eq!(start_after, 25);
-    assert_eq!(count_after, 20);
+    assert_eq!(count_after, 16);
 }
 
 #[test]
 fn visible_range_updates_with_new_candles() {
     assert_eq!(visible_range(60, 1.0, 0.0), (28, 32));
     assert_eq!(visible_range(70, 1.0, 0.0), (38, 32));
-    assert_eq!(visible_range(70, 2.0, 0.0), (50, 20));
+    assert_eq!(visible_range(70, 2.0, 0.0), (54, 16));
 }

--- a/tests/candle_width_max_zoom.rs
+++ b/tests/candle_width_max_zoom.rs
@@ -1,0 +1,12 @@
+use price_chart_wasm::infrastructure::rendering::renderer::{MIN_ELEMENT_WIDTH, SPACING_RATIO};
+use wasm_bindgen_test::*;
+
+#[wasm_bindgen_test]
+fn candle_width_at_max_zoom() {
+    let max_zoom: f64 = 32.0;
+    let visible = ((32.0f64 / max_zoom).max(1.0)) as usize;
+    let step_size = 2.0 / visible as f32;
+    let candle_width = (step_size * (1.0 - SPACING_RATIO)).max(MIN_ELEMENT_WIDTH);
+    let pixel_width = candle_width * 400.0; // canvas width 800 -> half width per NDC unit
+    assert!(pixel_width >= 30.0, "width {:.2} too small", pixel_width);
+}

--- a/tests/visible_range.rs
+++ b/tests/visible_range.rs
@@ -3,7 +3,7 @@ use price_chart_wasm::app::visible_range;
 #[test]
 fn visible_range_basic() {
     assert_eq!(visible_range(1000, 1.0, 0.0), (968, 32));
-    assert_eq!(visible_range(50, 2.0, 0.0), (30, 20));
+    assert_eq!(visible_range(50, 2.0, 0.0), (34, 16));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- allow zooming to a single candle
- adjust zoom limit check in `app` tests
- update visible range tests
- update axis zoom test expectations
- add coverage for candle width at max zoom
- document wider zoom range

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684d72258cb48331980526f63e377d03