### PR TITLE
Normalize wick vertex types

### DIFF
--- a/src/infrastructure/rendering/gpu_structures.rs
+++ b/src/infrastructure/rendering/gpu_structures.rs
@@ -40,14 +40,19 @@ impl CandleVertex {
         }
     }
 
-    /// Create vertex for the candle wick
+    /// Create vertex for the candle wick (used for grid lines)
     pub fn wick_vertex(x: f32, y: f32) -> Self {
-        Self {
-            position_x: x,
-            position_y: y,
-            element_type: 1.0, // wick
-            color_type: 0.5,   // neutral color for wick
-        }
+        Self { position_x: x, position_y: y, element_type: 1.0, color_type: 0.5 }
+    }
+
+    /// Create vertex for the upper wick
+    pub fn upper_wick_vertex(x: f32, y: f32) -> Self {
+        Self { position_x: x, position_y: y, element_type: 1.0, color_type: 0.5 }
+    }
+
+    /// Create vertex for the lower wick
+    pub fn lower_wick_vertex(x: f32, y: f32) -> Self {
+        Self { position_x: x, position_y: y, element_type: 1.6, color_type: 0.5 }
     }
 
     /// Create vertex for an indicator line

--- a/tests/vs_transform.rs
+++ b/tests/vs_transform.rs
@@ -1,0 +1,48 @@
+use price_chart_wasm::infrastructure::rendering::gpu_structures::{CandleInstance, CandleVertex};
+use wasm_bindgen_test::*;
+
+fn apply_vs(v: &CandleVertex, inst: &CandleInstance) -> (f32, f32) {
+    let x = inst.x + v.position_x * inst.width;
+    let y = if v.element_type < 0.5 {
+        inst.body_bottom + (inst.body_top - inst.body_bottom) * v.position_y
+    } else if v.element_type < 1.5 {
+        inst.body_top + (inst.high - inst.body_top) * v.position_y
+    } else {
+        inst.low + (inst.body_bottom - inst.low) * v.position_y
+    };
+    (x, y)
+}
+
+#[wasm_bindgen_test]
+fn vertex_shader_formula() {
+    let inst = CandleInstance {
+        x: 0.3,
+        width: 0.2,
+        body_top: 0.6,
+        body_bottom: 0.4,
+        high: 0.7,
+        low: 0.3,
+        bullish: 1.0,
+        _padding: 0.0,
+    };
+
+    let v = CandleVertex::body_vertex(-0.5, 0.0, true);
+    let (x, y) = apply_vs(&v, &inst);
+    assert!((x - 0.2).abs() < 1e-6);
+    assert!((y - inst.body_bottom).abs() < 1e-6);
+
+    let v = CandleVertex::body_vertex(0.5, 1.0, true);
+    let (x, y) = apply_vs(&v, &inst);
+    assert!((x - 0.4).abs() < 1e-6);
+    assert!((y - inst.body_top).abs() < 1e-6);
+
+    let v = CandleVertex::upper_wick_vertex(0.0, 1.0);
+    let (x, y) = apply_vs(&v, &inst);
+    assert!((x - inst.x).abs() < 1e-6);
+    assert!((y - inst.high).abs() < 1e-6);
+
+    let v = CandleVertex::lower_wick_vertex(0.0, 0.0);
+    let (x, y) = apply_vs(&v, &inst);
+    assert!((x - inst.x).abs() < 1e-6);
+    assert!((y - inst.low).abs() < 1e-6);
+}


### PR DESCRIPTION
## Summary
- keep vertex coordinates relative for candle geometry
- add separate upper/lower wick vertices
- adjust geometry builder to output normalized vertices
- verify shader math for candle vertices

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`

------
https://chatgpt.com/codex/tasks/task_e_684d7817644c83318dc7047b0e746505