### PR TITLE
Add failing test for single candle offset

### DIFF
--- a/tests/offset.rs
+++ b/tests/offset.rs
@@ -55,3 +55,9 @@ fn candle_positioning_monotonic() {
     // Ensure the last position is exactly 1.0
     assert!((positions.last().unwrap() - 1.0).abs() < f32::EPSILON);
 }
+
+#[wasm_bindgen_test]
+fn single_candle_centered() {
+    let x = candle_x_position(0, 1);
+    assert!((x - 0.0).abs() < f32::EPSILON);
+}


### PR DESCRIPTION
## Summary
- add `single_candle_centered` test for `candle_x_position`

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684d7af3325c833198f3bf8f1a3d39c6