### PR TITLE
Add failing test for single candle position

### DIFF
--- a/tests/offset.rs
+++ b/tests/offset.rs
@@ -31,6 +31,13 @@ fn candle_positioning_edge_cases() {
 }
 
 #[wasm_bindgen_test]
+fn single_candle_centered() {
+    // When only one candle is visible it should be centered at x=0.0
+    let pos = candle_x_position(0, 1);
+    assert!((pos - 0.0).abs() < f32::EPSILON);
+}
+
+#[wasm_bindgen_test]
 fn candle_positioning_monotonic() {
     // Test that positions are monotonically increasing
     let visible = 5;


### PR DESCRIPTION
## Summary
- add `single_candle_centered` test expecting 0.0 for single candle

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684d7ae334588331928f1a7003231149