### PR TITLE
update comment for single candle positioning

### DIFF
--- a/tests/offset.rs
+++ b/tests/offset.rs
@@ -19,7 +19,7 @@ fn candle_offset_calculation() {
 
 #[wasm_bindgen_test]
 fn candle_positioning_edge_cases() {
-    // Test with a single candle - should be centered (x=1.0)
+    // Test with a single candle - it should be on the right edge (x=1.0)
     let x_single = candle_x_position(0, 1);
     assert!((x_single - 1.0).abs() < f32::EPSILON);
 


### PR DESCRIPTION
## Summary
- clarify that a single candle sits at `x=1.0`

## Testing
- `cargo check --tests --benches` *(fails: `single_candle_centered` defined multiple times)*
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings` *(fails: `single_candle_centered` defined multiple times)*

------
https://chatgpt.com/codex/tasks/task_e_684d7d43391083319fbcf72ae0538192