### PR TITLE
Add missing FPS check

### DIFF
--- a/scripts/parse_perf_log.py
+++ b/scripts/parse_perf_log.py
@@ -15,6 +15,10 @@ with open(log_path) as f:
         if m:
             fps_values.append(float(m.group(1)))
 
+if not fps_values:
+    print("No FPS data found in log")
+    sys.exit(1)
+
 fps = sum(fps_values) / len(fps_values) if fps_values else 0.0
 
 with open(out_path, "w") as f:

--- a/tests/offset.rs
+++ b/tests/offset.rs
@@ -62,9 +62,3 @@ fn candle_positioning_monotonic() {
     // Ensure the last position is exactly 1.0
     assert!((positions.last().unwrap() - 1.0).abs() < f32::EPSILON);
 }
-
-#[wasm_bindgen_test]
-fn single_candle_centered() {
-    let x = candle_x_position(0, 1);
-    assert!((x - 0.0).abs() < f32::EPSILON);
-}

--- a/tests/parse_perf_log_script.py
+++ b/tests/parse_perf_log_script.py
@@ -1,0 +1,16 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_no_fps_in_log(tmp_path):
+    log = tmp_path / "log.txt"
+    log.write_text("some output without fps\n")
+    output = tmp_path / "result.json"
+    result = subprocess.run(
+        [sys.executable, str(Path(__file__).resolve().parent.parent / "scripts" / "parse_perf_log.py"),
+         str(log), str(output)],
+        capture_output=True, text=True
+    )
+    assert result.returncode == 1
+    assert "No FPS data found in log" in result.stdout


### PR DESCRIPTION
## Summary
- validate presence of FPS data in `parse_perf_log.py`
- test script termination when FPS lines are absent
- remove duplicate function from `offset.rs`

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`
- `pytest tests/compare_fps_script.py tests/parse_perf_log_script.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684d7d1ba4c883319519b4c30cf23f2b