### PR TITLE
Fix coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           toolchain: nightly
           targets: wasm32-unknown-unknown
+          components: rust-src
       - name: Install wasm-pack
         run: cargo install wasm-pack
       - name: Install wasm-tools

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ jobs:
         with:
           toolchain: nightly
           targets: wasm32-unknown-unknown
+          components: rust-src
       - name: Install rustup if needed
         run: |
           if ! command -v rustup &>/dev/null; then

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Coverage can be collected with `cargo-llvm-cov`:
 ```bash
 cargo llvm-cov --workspace --lcov --output-path lcov.info --target wasm32-unknown-unknown -Z build-std=std,panic_abort,profiler_builtins
 ```
+Make sure the `rust-src` component is installed before running the command.
 
 The generated `lcov.info` file can be uploaded by CI.
 The `coverage` workflow publishes the latest percentage to `docs/coverage.md`.


### PR DESCRIPTION
## Summary
- install `rust-src` in coverage and test workflows
- document `rust-src` requirement for coverage

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`

------
https://chatgpt.com/codex/tasks/task_e_684d91ad881883318a51380d6c034dc5