### PR TITLE
Fix perf pipelines

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,9 +16,21 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+          targets: wasm32-unknown-unknown
       - uses: actions/setup-python@v4
         with:
           python-version: '3.x'
+      - name: Install rustup if needed
+        run: |
+          if ! command -v rustup &>/dev/null; then
+            curl --proto '=https' --tlsv1.2 --retry 10 --retry-delay 5 --retry-connrefused --location --silent --show-error --fail https://sh.rustup.rs | sh -s -- --default-toolchain none -y
+            echo "$CARGO_HOME/bin" >> $GITHUB_PATH
+          fi
+      - name: Install wasm-pack
+        run: cargo install wasm-pack --version 0.13.1
       - name: Run benchmarks
         run: |
           wasm-pack test --headless --chrome -- --nocapture | tee perf.log

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -17,8 +17,14 @@ jobs:
         with:
           toolchain: stable
           targets: wasm32-unknown-unknown
+      - name: Install rustup if needed
+        run: |
+          if ! command -v rustup &>/dev/null; then
+            curl --proto '=https' --tlsv1.2 --retry 10 --retry-delay 5 --retry-connrefused --location --silent --show-error --fail https://sh.rustup.rs | sh -s -- --default-toolchain none -y
+            echo "$CARGO_HOME/bin" >> $GITHUB_PATH
+          fi
       - name: Install wasm-pack
-        run: cargo install wasm-pack
+        run: cargo install wasm-pack --version 0.13.1
       - name: Run benchmarks
         run: wasm-pack test --headless --chrome -- --nocapture | tee perf.log
       - name: Upload results


### PR DESCRIPTION
## Summary
- set up Rust toolchain and wasm‑pack in perf workflows so that benchmarks run in CI

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684da18c5fdc833187e7a3726f494147