### PR TITLE
Use CandleGeometry for candle vertices

### DIFF
--- a/src/infrastructure/rendering/gpu_structures.rs
+++ b/src/infrastructure/rendering/gpu_structures.rs
@@ -45,16 +45,6 @@ impl CandleVertex {
         Self { position_x: x, position_y: y, element_type: 1.0, color_type: 0.5 }
     }
 
-    /// Create vertex for the upper wick
-    pub fn upper_wick_vertex(x: f32, y: f32) -> Self {
-        Self { position_x: x, position_y: y, element_type: 1.0, color_type: 0.5 }
-    }
-
-    /// Create vertex for the lower wick
-    pub fn lower_wick_vertex(x: f32, y: f32) -> Self {
-        Self { position_x: x, position_y: y, element_type: 1.6, color_type: 0.5 }
-    }
-
     /// Create vertex for an indicator line
     pub fn indicator_vertex(x: f32, y: f32, indicator_type: IndicatorType) -> Self {
         let color_type = match indicator_type {

--- a/src/infrastructure/rendering/renderer/geometry.rs
+++ b/src/infrastructure/rendering/renderer/geometry.rs
@@ -196,73 +196,20 @@ impl WebGpuRenderer {
                 _padding: 0.0,
             });
 
-            // Candle body vertices in local space
-            let body_vertices = vec![
-                CandleVertex::body_vertex(-0.5, 0.0, is_bullish),
-                CandleVertex::body_vertex(0.5, 0.0, is_bullish),
-                CandleVertex::body_vertex(-0.5, 1.0, is_bullish),
-                CandleVertex::body_vertex(0.5, 0.0, is_bullish),
-                CandleVertex::body_vertex(0.5, 1.0, is_bullish),
-                CandleVertex::body_vertex(-0.5, 1.0, is_bullish),
-            ];
-            vertices.extend_from_slice(&body_vertices);
-
-            // Round corners with small triangles
-            // Increase rounding for more pronounced candle corners
-            let corner = candle_width * 0.35;
-            let body_height = actual_body_top - body_bottom;
-            let corner_x = corner / candle_width;
-            let corner_y = corner / body_height;
-            let corners = vec![
-                // Top left
-                CandleVertex::body_vertex(-0.5, 1.0 - corner_y, is_bullish),
-                CandleVertex::body_vertex(-0.5 + corner_x, 1.0, is_bullish),
-                CandleVertex::body_vertex(-0.5, 1.0, is_bullish),
-                // Top right
-                CandleVertex::body_vertex(0.5 - corner_x, 1.0, is_bullish),
-                CandleVertex::body_vertex(0.5, 1.0 - corner_y, is_bullish),
-                CandleVertex::body_vertex(0.5, 1.0, is_bullish),
-                // Bottom left
-                CandleVertex::body_vertex(-0.5, 0.0, is_bullish),
-                CandleVertex::body_vertex(-0.5 + corner_x, 0.0, is_bullish),
-                CandleVertex::body_vertex(-0.5, corner_y, is_bullish),
-                // Bottom right
-                CandleVertex::body_vertex(0.5, 0.0, is_bullish),
-                CandleVertex::body_vertex(0.5, corner_y, is_bullish),
-                CandleVertex::body_vertex(0.5 - corner_x, 0.0, is_bullish),
-            ];
-            vertices.extend_from_slice(&corners);
-
-            // Add wicks (upper and lower)
-            let wick_width = (candle_width * 0.15).max(MIN_ELEMENT_WIDTH * 0.5);
-            let wick_half = wick_width * 0.5;
-            let wick_offset = wick_half / candle_width;
-
-            // Upper wick
-            if high_y > actual_body_top {
-                let upper_wick = vec![
-                    CandleVertex::upper_wick_vertex(-wick_offset, 0.0),
-                    CandleVertex::upper_wick_vertex(wick_offset, 0.0),
-                    CandleVertex::upper_wick_vertex(-wick_offset, 1.0),
-                    CandleVertex::upper_wick_vertex(wick_offset, 0.0),
-                    CandleVertex::upper_wick_vertex(wick_offset, 1.0),
-                    CandleVertex::upper_wick_vertex(-wick_offset, 1.0),
-                ];
-                vertices.extend_from_slice(&upper_wick);
-            }
-
-            // Lower wick
-            if low_y < body_bottom {
-                let lower_wick = vec![
-                    CandleVertex::lower_wick_vertex(-wick_offset, 0.0),
-                    CandleVertex::lower_wick_vertex(wick_offset, 0.0),
-                    CandleVertex::lower_wick_vertex(-wick_offset, 1.0),
-                    CandleVertex::lower_wick_vertex(wick_offset, 0.0),
-                    CandleVertex::lower_wick_vertex(wick_offset, 1.0),
-                    CandleVertex::lower_wick_vertex(-wick_offset, 1.0),
-                ];
-                vertices.extend_from_slice(&lower_wick);
-            }
+            let candle_vertices = CandleGeometry::create_candle_vertices(
+                candle.timestamp.as_f64(),
+                candle.ohlcv.open.value() as f32,
+                candle.ohlcv.high.value() as f32,
+                candle.ohlcv.low.value() as f32,
+                candle.ohlcv.close.value() as f32,
+                x,
+                open_y,
+                high_y,
+                low_y,
+                close_y,
+                candle_width,
+            );
+            vertices.extend_from_slice(&candle_vertices);
         }
 
         // Calculate moving averages for indicator lines using the full data set

--- a/tests/vs_transform.rs
+++ b/tests/vs_transform.rs
@@ -36,12 +36,12 @@ fn vertex_shader_formula() {
     assert!((x - 0.4).abs() < 1e-6);
     assert!((y - inst.body_top).abs() < 1e-6);
 
-    let v = CandleVertex::upper_wick_vertex(0.0, 1.0);
+    let v = CandleVertex::wick_vertex(0.0, 1.0);
     let (x, y) = apply_vs(&v, &inst);
     assert!((x - inst.x).abs() < 1e-6);
     assert!((y - inst.high).abs() < 1e-6);
 
-    let v = CandleVertex::lower_wick_vertex(0.0, 0.0);
+    let v = CandleVertex { position_x: 0.0, position_y: 0.0, element_type: 2.0, color_type: 0.5 };
     let (x, y) = apply_vs(&v, &inst);
     assert!((x - inst.x).abs() < 1e-6);
     assert!((y - inst.low).abs() < 1e-6);


### PR DESCRIPTION
## Summary
- simplify candle mesh generation
- remove obsolete wick helpers
- adjust tests for wick vertices

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684dc60d922c8331baaf23351a557738