### PR TITLE
Add caching to coverage workflows

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,6 +21,16 @@ jobs:
           toolchain: nightly
           targets: wasm32-unknown-unknown
           components: rust-src
+      - name: Cache cargo
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
       - name: Install wasm-pack
         run: cargo install wasm-pack
       - name: Install wasm-tools

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,16 @@ jobs:
           toolchain: nightly
           targets: wasm32-unknown-unknown
           components: rust-src
+      - name: Cache cargo
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
       - name: Install rustup if needed
         run: |
           if ! command -v rustup &>/dev/null; then
@@ -33,12 +43,3 @@ jobs:
         run: cargo clippy --all-targets --all-features -- -D warnings || echo 'Clippy warnings found'
       - name: Run tests
         run: wasm-pack test --headless --chrome
-      - name: Install cargo-llvm-cov
-        run: cargo install cargo-llvm-cov
-      - name: Generate coverage
-        run: cargo llvm-cov --workspace --lcov --output-path lcov.info --target wasm32-unknown-unknown -Z build-std=std,panic_abort
-      - name: Upload coverage
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage
-          path: lcov.info


### PR DESCRIPTION
## Summary
- add Cargo caching to speed up the coverage job
- cache dependencies in the test workflow
- remove coverage generation from PR tests

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684dde344460833196f5c1b942e79c1f