### PR TITLE
Remove redundant rustup step from workflows

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -23,12 +23,6 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.x'
-      - name: Install rustup if needed
-        run: |
-          if ! command -v rustup &>/dev/null; then
-            curl --proto '=https' --tlsv1.2 --retry 10 --retry-delay 5 --retry-connrefused --location --silent --show-error --fail https://sh.rustup.rs | sh -s -- --default-toolchain none -y
-            echo "$CARGO_HOME/bin" >> $GITHUB_PATH
-          fi
       - name: Install wasm-pack
         run: cargo install wasm-pack --version 0.13.1
       - name: Run benchmarks

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -17,12 +17,6 @@ jobs:
         with:
           toolchain: stable
           targets: wasm32-unknown-unknown
-      - name: Install rustup if needed
-        run: |
-          if ! command -v rustup &>/dev/null; then
-            curl --proto '=https' --tlsv1.2 --retry 10 --retry-delay 5 --retry-connrefused --location --silent --show-error --fail https://sh.rustup.rs | sh -s -- --default-toolchain none -y
-            echo "$CARGO_HOME/bin" >> $GITHUB_PATH
-          fi
       - name: Install wasm-pack
         run: cargo install wasm-pack --version 0.13.1
       - name: Run benchmarks

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,12 +25,6 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
-      - name: Install rustup if needed
-        run: |
-          if ! command -v rustup &>/dev/null; then
-            curl --proto '=https' --tlsv1.2 --retry 10 --retry-delay 5 --retry-connrefused --location --silent --show-error --fail https://sh.rustup.rs | sh -s -- --default-toolchain none -y
-            echo "$CARGO_HOME/bin" >> $GITHUB_PATH
-          fi
       - name: Install wasm-pack
         run: cargo install wasm-pack --version 0.13.1
       - name: Install wasm-tools


### PR DESCRIPTION
## Summary
- update CI configs to drop the manual rustup installation

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684de13105ec8331b009b9d23d8bfc1d