### PR TITLE
Fix pan direction and add tests

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -591,7 +591,7 @@ fn ChartContainer() -> impl IntoView {
                 let delta_x = mouse_x - last_x;
                 pan_offset().update(|o| {
                     let pan_sensitivity = zoom_level().with_untracked(|val| *val) * 0.001;
-                    *o += delta_x * pan_sensitivity;
+                    *o -= delta_x * pan_sensitivity;
                 });
                 chart_signal.update(|ch| {
                     let factor_x = -(delta_x as f32) / ch.viewport.width as f32;

--- a/tests/pan_offset.rs
+++ b/tests/pan_offset.rs
@@ -1,0 +1,20 @@
+use price_chart_wasm::app::{HISTORY_FETCH_THRESHOLD, should_fetch_history};
+
+#[test]
+fn pan_direction_and_history_activation() {
+    let mut offset = 0.0;
+    let delta_x = 10.0;
+    let zoom_level = 1.0;
+    let pan_sensitivity = zoom_level * 0.001;
+
+    // Simulate dragging to the right
+    offset -= delta_x * pan_sensitivity;
+    assert!(offset < 0.0);
+    assert!(!should_fetch_history(offset));
+
+    // Drag far enough to cross the history threshold
+    let mut offset_big = 0.0;
+    let delta_x_big = (HISTORY_FETCH_THRESHOLD.abs() + 1.0) / pan_sensitivity;
+    offset_big -= delta_x_big * pan_sensitivity;
+    assert!(should_fetch_history(offset_big));
+}


### PR DESCRIPTION
## Summary
- update panning sign so right drag makes negative offset
- check that pan_offset turns negative and history fetch triggers

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684de73ca4288331a7d58e277497d63e