### PR TITLE
History buffer for candle series

### DIFF
--- a/tests/series_expansion.rs
+++ b/tests/series_expansion.rs
@@ -1,0 +1,36 @@
+use price_chart_wasm::app::visible_range;
+use price_chart_wasm::domain::chart::{Chart, value_objects::ChartType};
+use price_chart_wasm::domain::market_data::{Candle, OHLCV, Price, Timestamp, Volume};
+use wasm_bindgen_test::*;
+
+fn make_candle(i: u64) -> Candle {
+    Candle::new(
+        Timestamp::from_millis(i * 60_000),
+        OHLCV::new(
+            Price::from(1.0),
+            Price::from(1.0),
+            Price::from(1.0),
+            Price::from(1.0),
+            Volume::from(1.0),
+        ),
+    )
+}
+
+#[wasm_bindgen_test]
+fn series_extension_preserves_view() {
+    let mut chart = Chart::new("test".to_string(), ChartType::Candlestick, 400);
+    for i in 100..200 {
+        chart.add_candle(make_candle(i));
+    }
+
+    let (start_before, visible) = visible_range(chart.get_candle_count(), 1.0, -20.0);
+
+    for i in 0..100 {
+        chart.add_candle(make_candle(i));
+    }
+
+    let (start_after, visible_after) = visible_range(chart.get_candle_count(), 1.0, -20.0);
+
+    assert_eq!(visible, visible_after);
+    assert_eq!(start_after, start_before + 100);
+}


### PR DESCRIPTION
## Summary
- keep extra candles in memory
- clamp visible range using extra buffer
- load extra candles when fetching history
- verify series extension doesn't shift visible data

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684de74ccf10833199e077590143b897