### PR TITLE
Add indicator legend checkboxes

### DIFF
--- a/src/infrastructure/rendering/renderer/render_loop.rs
+++ b/src/infrastructure/rendering/renderer/render_loop.rs
@@ -260,6 +260,10 @@ impl WebGpuRenderer {
         }
     }
 
+    pub fn line_visibility(&self) -> LineVisibility {
+        self.line_visibility.clone()
+    }
+
     /// Check if the legend checkbox was clicked
     pub fn check_legend_checkbox_click(&self, mouse_x: f32, mouse_y: f32) -> Option<String> {
         const LEGEND_LEFT: f32 = 10.0;


### PR DESCRIPTION
## Summary
- add `Legend` component with checkbox toggles
- expose line visibility via `WebGpuRenderer::line_visibility`
- insert legend below the chart canvas
- test checkbox toggling through wasm-bindgen

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684deb8af66083318080944dae1bbb99