### PR TITLE
Add width-dependent corner segments

### DIFF
--- a/src/infrastructure/rendering/gpu_structures.rs
+++ b/src/infrastructure/rendering/gpu_structures.rs
@@ -278,8 +278,13 @@ impl ChartUniforms {
 pub struct CandleGeometry;
 
 impl CandleGeometry {
-    /// Number of segments used to approximate rounded candle corners
-    const CORNER_SEGMENTS: usize = 6;
+    /// Base number of segments for rounded corners
+    const BASE_CORNER_SEGMENTS: usize = 6;
+
+    /// Determine corner segment count based on candle width
+    fn corner_segments(width: f32) -> usize {
+        if width >= 0.04 { 12 } else { Self::BASE_CORNER_SEGMENTS }
+    }
     /// Create vertices for a single candle
     #[allow(clippy::too_many_arguments)]
     pub fn create_candle_vertices(
@@ -363,10 +368,11 @@ impl CandleGeometry {
         ]);
 
         // Helper to build corner arcs
+        let segments = Self::corner_segments(width);
         let mut add_arc = |cx: f32, cy: f32, start: f32, end: f32| {
-            let step = (end - start) / Self::CORNER_SEGMENTS as f32;
+            let step = (end - start) / segments as f32;
             let mut angle = start;
-            for _ in 0..Self::CORNER_SEGMENTS {
+            for _ in 0..segments {
                 let x1 = cx + corner * angle.cos();
                 let y1 = cy + corner * angle.sin();
                 angle += step;

--- a/tests/geometry.rs
+++ b/tests/geometry.rs
@@ -75,3 +75,17 @@ fn candle_color_logic() {
     );
     assert!((bearish[0].color_type - 0.0).abs() < f32::EPSILON);
 }
+
+#[wasm_bindgen_test]
+fn corner_segment_vertex_count() {
+    let narrow = CandleGeometry::create_candle_vertices(
+        0.0, 1.0, 1.1, 0.9, 1.05, 0.0, 0.0, 0.3, -0.3, 0.2, 0.02,
+    );
+
+    let wide = CandleGeometry::create_candle_vertices(
+        0.0, 1.0, 1.1, 0.9, 1.05, 0.0, 0.0, 0.3, -0.3, 0.2, 0.05,
+    );
+
+    assert_eq!(narrow.len(), 114);
+    assert_eq!(wide.len(), 186);
+}


### PR DESCRIPTION
## Summary
- adapt candle corner segments based on width
- update arc generation accordingly
- test vertex count for narrow and wide candles

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`

------
https://chatgpt.com/codex/tasks/task_e_684df232b1e0833182c982e379b18e1f