### PR TITLE
Fix corner rounding for small candles

### DIFF
--- a/tests/geometry.rs
+++ b/tests/geometry.rs
@@ -75,3 +75,11 @@ fn candle_color_logic() {
     );
     assert!((bearish[0].color_type - 0.0).abs() < f32::EPSILON);
 }
+
+#[wasm_bindgen_test]
+fn tiny_candle_no_rounding() {
+    let verts = CandleGeometry::create_candle_vertices(
+        0.0, 1.0, 1.5, 0.5, 1.0002, 0.0, 0.0, 0.1, -0.1, 0.0002, 0.1,
+    );
+    assert_eq!(verts.len(), 18);
+}


### PR DESCRIPTION
## Summary
- handle tiny candle height in corner calculation
- skip rounding when corners are too small
- test for candles without rounding

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`

------
https://chatgpt.com/codex/tasks/task_e_684df234d0cc833180b4ffa964102cac