### PR TITLE
Handle small candle rounding

### DIFF
--- a/src/infrastructure/rendering/gpu_structures.rs
+++ b/src/infrastructure/rendering/gpu_structures.rs
@@ -308,14 +308,22 @@ impl CandleGeometry {
         let body_top = if is_bullish { close_y } else { open_y };
         let body_bottom = if is_bullish { open_y } else { close_y };
 
-        let corner = width * 0.35;
+        let corner = f32::min(width * 0.35, (body_top - body_bottom).abs() * 0.5);
 
         let left = x_normalized - half_width;
         let right = x_normalized + half_width;
-        let inner_left = left + corner;
-        let inner_right = right - corner;
-        let inner_top = body_top - corner;
-        let inner_bottom = body_bottom + corner;
+        let mut inner_left = left + corner;
+        let mut inner_right = right - corner;
+        let mut inner_top = body_top - corner;
+        let mut inner_bottom = body_bottom + corner;
+
+        let rounded = corner >= 0.001;
+        if !rounded {
+            inner_left = left;
+            inner_right = right;
+            inner_top = body_top;
+            inner_bottom = body_bottom;
+        }
 
         // Central rectangle
         vertices.extend_from_slice(&[
@@ -327,71 +335,73 @@ impl CandleGeometry {
             CandleVertex::body_vertex(inner_left, inner_top, is_bullish),
         ]);
 
-        // Top rectangle
-        vertices.extend_from_slice(&[
-            CandleVertex::body_vertex(inner_left, inner_top, is_bullish),
-            CandleVertex::body_vertex(inner_right, inner_top, is_bullish),
-            CandleVertex::body_vertex(inner_left, body_top, is_bullish),
-            CandleVertex::body_vertex(inner_right, inner_top, is_bullish),
-            CandleVertex::body_vertex(inner_right, body_top, is_bullish),
-            CandleVertex::body_vertex(inner_left, body_top, is_bullish),
-        ]);
+        if rounded {
+            // Top rectangle
+            vertices.extend_from_slice(&[
+                CandleVertex::body_vertex(inner_left, inner_top, is_bullish),
+                CandleVertex::body_vertex(inner_right, inner_top, is_bullish),
+                CandleVertex::body_vertex(inner_left, body_top, is_bullish),
+                CandleVertex::body_vertex(inner_right, inner_top, is_bullish),
+                CandleVertex::body_vertex(inner_right, body_top, is_bullish),
+                CandleVertex::body_vertex(inner_left, body_top, is_bullish),
+            ]);
 
-        // Bottom rectangle
-        vertices.extend_from_slice(&[
-            CandleVertex::body_vertex(inner_left, body_bottom, is_bullish),
-            CandleVertex::body_vertex(inner_right, body_bottom, is_bullish),
-            CandleVertex::body_vertex(inner_left, inner_bottom, is_bullish),
-            CandleVertex::body_vertex(inner_right, body_bottom, is_bullish),
-            CandleVertex::body_vertex(inner_right, inner_bottom, is_bullish),
-            CandleVertex::body_vertex(inner_left, inner_bottom, is_bullish),
-        ]);
+            // Bottom rectangle
+            vertices.extend_from_slice(&[
+                CandleVertex::body_vertex(inner_left, body_bottom, is_bullish),
+                CandleVertex::body_vertex(inner_right, body_bottom, is_bullish),
+                CandleVertex::body_vertex(inner_left, inner_bottom, is_bullish),
+                CandleVertex::body_vertex(inner_right, body_bottom, is_bullish),
+                CandleVertex::body_vertex(inner_right, inner_bottom, is_bullish),
+                CandleVertex::body_vertex(inner_left, inner_bottom, is_bullish),
+            ]);
 
-        // Left rectangle
-        vertices.extend_from_slice(&[
-            CandleVertex::body_vertex(left, inner_bottom, is_bullish),
-            CandleVertex::body_vertex(inner_left, inner_bottom, is_bullish),
-            CandleVertex::body_vertex(left, inner_top, is_bullish),
-            CandleVertex::body_vertex(inner_left, inner_bottom, is_bullish),
-            CandleVertex::body_vertex(inner_left, inner_top, is_bullish),
-            CandleVertex::body_vertex(left, inner_top, is_bullish),
-        ]);
+            // Left rectangle
+            vertices.extend_from_slice(&[
+                CandleVertex::body_vertex(left, inner_bottom, is_bullish),
+                CandleVertex::body_vertex(inner_left, inner_bottom, is_bullish),
+                CandleVertex::body_vertex(left, inner_top, is_bullish),
+                CandleVertex::body_vertex(inner_left, inner_bottom, is_bullish),
+                CandleVertex::body_vertex(inner_left, inner_top, is_bullish),
+                CandleVertex::body_vertex(left, inner_top, is_bullish),
+            ]);
 
-        // Right rectangle
-        vertices.extend_from_slice(&[
-            CandleVertex::body_vertex(inner_right, inner_bottom, is_bullish),
-            CandleVertex::body_vertex(right, inner_bottom, is_bullish),
-            CandleVertex::body_vertex(inner_right, inner_top, is_bullish),
-            CandleVertex::body_vertex(right, inner_bottom, is_bullish),
-            CandleVertex::body_vertex(right, inner_top, is_bullish),
-            CandleVertex::body_vertex(inner_right, inner_top, is_bullish),
-        ]);
+            // Right rectangle
+            vertices.extend_from_slice(&[
+                CandleVertex::body_vertex(inner_right, inner_bottom, is_bullish),
+                CandleVertex::body_vertex(right, inner_bottom, is_bullish),
+                CandleVertex::body_vertex(inner_right, inner_top, is_bullish),
+                CandleVertex::body_vertex(right, inner_bottom, is_bullish),
+                CandleVertex::body_vertex(right, inner_top, is_bullish),
+                CandleVertex::body_vertex(inner_right, inner_top, is_bullish),
+            ]);
 
-        // Helper to build corner arcs
-        let segments = Self::corner_segments(width);
-        let mut add_arc = |cx: f32, cy: f32, start: f32, end: f32| {
-            let step = (end - start) / segments as f32;
-            let mut angle = start;
-            for _ in 0..segments {
-                let x1 = cx + corner * angle.cos();
-                let y1 = cy + corner * angle.sin();
-                angle += step;
-                let x2 = cx + corner * angle.cos();
-                let y2 = cy + corner * angle.sin();
-                vertices.push(CandleVertex::body_vertex(cx, cy, is_bullish));
-                vertices.push(CandleVertex::body_vertex(x1, y1, is_bullish));
-                vertices.push(CandleVertex::body_vertex(x2, y2, is_bullish));
-            }
-        };
+            // Helper to build corner arcs
+            let segments = Self::corner_segments(width);
+            let mut add_arc = |cx: f32, cy: f32, start: f32, end: f32| {
+                let step = (end - start) / segments as f32;
+                let mut angle = start;
+                for _ in 0..segments {
+                    let x1 = cx + corner * angle.cos();
+                    let y1 = cy + corner * angle.sin();
+                    angle += step;
+                    let x2 = cx + corner * angle.cos();
+                    let y2 = cy + corner * angle.sin();
+                    vertices.push(CandleVertex::body_vertex(cx, cy, is_bullish));
+                    vertices.push(CandleVertex::body_vertex(x1, y1, is_bullish));
+                    vertices.push(CandleVertex::body_vertex(x2, y2, is_bullish));
+                }
+            };
 
-        // Top left arc
-        add_arc(inner_left, inner_top, std::f32::consts::FRAC_PI_2, std::f32::consts::PI);
-        // Top right arc
-        add_arc(inner_right, inner_top, 0.0, std::f32::consts::FRAC_PI_2);
-        // Bottom right arc
-        add_arc(inner_right, inner_bottom, -std::f32::consts::FRAC_PI_2, 0.0);
-        // Bottom left arc
-        add_arc(inner_left, inner_bottom, std::f32::consts::PI, std::f32::consts::PI * 1.5);
+            // Top left arc
+            add_arc(inner_left, inner_top, std::f32::consts::FRAC_PI_2, std::f32::consts::PI);
+            // Top right arc
+            add_arc(inner_right, inner_top, 0.0, std::f32::consts::FRAC_PI_2);
+            // Bottom right arc
+            add_arc(inner_right, inner_bottom, -std::f32::consts::FRAC_PI_2, 0.0);
+            // Bottom left arc
+            add_arc(inner_left, inner_bottom, std::f32::consts::PI, std::f32::consts::PI * 1.5);
+        }
 
         // Create lines for the upper and lower wicks
         let wick_width = width * 0.1; // wick is thinner than the body

--- a/tests/geometry.rs
+++ b/tests/geometry.rs
@@ -89,3 +89,11 @@ fn corner_segment_vertex_count() {
     assert_eq!(narrow.len(), 114);
     assert_eq!(wide.len(), 186);
 }
+
+#[wasm_bindgen_test]
+fn very_low_candle_no_rounding() {
+    let low = CandleGeometry::create_candle_vertices(
+        0.0, 1.0, 1.05, 0.95, 1.0, 0.0, 0.0, 0.05, -0.05, 0.0, 0.05,
+    );
+    assert_eq!(low.len(), 18);
+}


### PR DESCRIPTION
## Summary
- adjust corner radius to consider candle height
- skip rounded corners for very short candles
- test that small candles have no rounded vertices

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684df51fa3c08331abd87b7d08f13b3d