### PR TITLE
Fix now button test lookup

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1375,7 +1375,7 @@ mod tests {
 
         pan_offset().set(5.0);
 
-        let now = find_button(&container, "Now");
+        let now = find_button(&container, "now");
         now.click();
 
         assert_eq!(pan_offset().get(), 0.0);


### PR DESCRIPTION
## Summary
- adjust label in `now_button_resets_pan` test

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`
- `cargo test` *(fails: Exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_684df76f5fb883319374023e2751ae3c