### PR TITLE
limit timeframe selector options

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -966,9 +966,6 @@ fn TimeframeSelector(chart: RwSignal<Chart>) -> impl IntoView {
         TimeInterval::FifteenMinutes,
         TimeInterval::ThirtyMinutes,
         TimeInterval::OneHour,
-        TimeInterval::OneDay,
-        TimeInterval::OneWeek,
-        TimeInterval::OneMonth,
     ];
 
     view! {


### PR DESCRIPTION
## Summary
- trim timeframe options to one hour

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684df759cc7c8331b057506c78541fef