### PR TITLE
Implement volume bar rendering

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1249,7 +1249,7 @@ async fn start_websocket_stream(chart: RwSignal<Chart>, set_status: WriteSignal<
 mod tests {
     use super::*;
     use crate::domain::chart::value_objects::ChartType;
-    use crate::domain::market_data::{Candle, OHLCV, Price, Timestamp, Volume};
+
     use wasm_bindgen::JsCast;
     use wasm_bindgen_test::*;
 

--- a/src/infrastructure/rendering/gpu_structures.rs
+++ b/src/infrastructure/rendering/gpu_structures.rs
@@ -282,6 +282,8 @@ impl CandleGeometry {
     const BASE_CORNER_SEGMENTS: usize = 6;
     /// Ratio of the candle width used for rounded corners
     const CORNER_RADIUS_RATIO: f32 = 0.15;
+    /// Maximum height of volume bars in NDC coordinates
+    pub const VOLUME_HEIGHT: f32 = 0.4;
 
     /// Determine corner segment count based on candle width
     fn corner_segments(width: f32) -> usize {
@@ -310,7 +312,8 @@ impl CandleGeometry {
         let body_top = if is_bullish { close_y } else { open_y };
         let body_bottom = if is_bullish { open_y } else { close_y };
 
-        let corner = f32::min(width * 0.35, (body_top - body_bottom).abs() * 0.5);
+        let corner =
+            f32::min(width * Self::CORNER_RADIUS_RATIO, (body_top - body_bottom).abs() * 0.5);
 
         let left = x_normalized - half_width;
         let right = x_normalized + half_width;
@@ -450,6 +453,28 @@ impl CandleGeometry {
             CandleVertex::current_price_vertex(-1.0, current_price_y + half_width),
             CandleVertex::current_price_vertex(1.0, current_price_y - half_width),
             CandleVertex::current_price_vertex(1.0, current_price_y + half_width),
+        ]
+    }
+
+    /// Create vertices for a volume bar
+    pub fn create_volume_vertices(
+        x_normalized: f32,
+        width: f32,
+        volume_ratio: f32,
+        is_bullish: bool,
+    ) -> Vec<CandleVertex> {
+        let half_width = width * 0.5;
+        let left = x_normalized - half_width;
+        let right = x_normalized + half_width;
+        let bottom = -1.0;
+        let top = bottom + volume_ratio.clamp(0.0, 1.0) * Self::VOLUME_HEIGHT;
+        vec![
+            CandleVertex::volume_vertex(left, bottom, is_bullish),
+            CandleVertex::volume_vertex(right, bottom, is_bullish),
+            CandleVertex::volume_vertex(left, top, is_bullish),
+            CandleVertex::volume_vertex(right, bottom, is_bullish),
+            CandleVertex::volume_vertex(right, top, is_bullish),
+            CandleVertex::volume_vertex(left, top, is_bullish),
         ]
     }
 

--- a/src/infrastructure/rendering/renderer/geometry.rs
+++ b/src/infrastructure/rendering/renderer/geometry.rs
@@ -128,6 +128,14 @@ impl WebGpuRenderer {
             normalized * 2.0 - 1.0
         };
 
+        let mut max_volume = 0.0f32;
+        for c in &visible_candles {
+            max_volume = max_volume.max(c.ohlcv.volume.value() as f32);
+        }
+        if max_volume <= 0.0 {
+            max_volume = 1.0;
+        }
+
         for (i, candle) in visible_candles.iter().enumerate() {
             let x = candle_x_position(i, visible_candles.len());
 
@@ -185,6 +193,11 @@ impl WebGpuRenderer {
                 candle_width,
             );
             vertices.extend_from_slice(&candle_vertices);
+
+            let vol_ratio = (candle.ohlcv.volume.value() as f32) / max_volume;
+            let volume_vertices =
+                CandleGeometry::create_volume_vertices(x, candle_width, vol_ratio, is_bullish);
+            vertices.extend_from_slice(&volume_vertices);
         }
 
         // Calculate moving averages for indicator lines using the full data set

--- a/src/infrastructure/rendering/renderer/mod.rs
+++ b/src/infrastructure/rendering/renderer/mod.rs
@@ -13,6 +13,7 @@ use crate::infrastructure::rendering::gpu_structures::{
 };
 use gloo::utils::document;
 use js_sys;
+use leptos::SignalSet;
 use std::cell::RefCell;
 use std::collections::VecDeque;
 use std::rc::Rc;
@@ -20,7 +21,6 @@ use wasm_bindgen::JsCast;
 use wasm_bindgen::JsValue;
 use web_sys::HtmlCanvasElement;
 use wgpu::util::DeviceExt;
-use leptos::SignalSet;
 thread_local! {
     static GLOBAL_RENDERER: RefCell<Option<Rc<RefCell<WebGpuRenderer>>>> = const { RefCell::new(None) };
 }

--- a/tests/geometry.rs
+++ b/tests/geometry.rs
@@ -101,6 +101,9 @@ fn corner_radius_ratio() {
     let corner = width * 0.15;
     let expected_x = x - width * 0.5 + corner;
     assert!((verts[0].position_x - expected_x).abs() < f32::EPSILON);
+}
+
+#[wasm_bindgen_test]
 fn very_low_candle_no_rounding() {
     let low = CandleGeometry::create_candle_vertices(
         0.0, 1.0, 1.05, 0.95, 1.0, 0.0, 0.0, 0.05, -0.05, 0.0, 0.05,

--- a/tests/volume_vertices.rs
+++ b/tests/volume_vertices.rs
@@ -1,0 +1,20 @@
+use price_chart_wasm::infrastructure::rendering::gpu_structures::CandleGeometry;
+use wasm_bindgen_test::*;
+
+#[wasm_bindgen_test]
+fn volume_vertex_basic() {
+    let verts = CandleGeometry::create_volume_vertices(0.0, 0.2, 1.0, true);
+    assert_eq!(verts.len(), 6);
+    for v in &verts {
+        assert!((v.element_type - 5.0).abs() < f32::EPSILON);
+    }
+}
+
+#[wasm_bindgen_test]
+fn volume_height_scaling() {
+    let low = CandleGeometry::create_volume_vertices(0.0, 0.2, 0.5, true);
+    let high = CandleGeometry::create_volume_vertices(0.0, 0.2, 1.0, true);
+    let low_top = low.iter().map(|v| v.position_y).fold(-1.0, f32::max);
+    let high_top = high.iter().map(|v| v.position_y).fold(-1.0, f32::max);
+    assert!(high_top > low_top);
+}


### PR DESCRIPTION
## Summary
- add constant `VOLUME_HEIGHT` for volume bar size
- generate volume bar geometry in renderer
- provide helper `create_volume_vertices`
- test volume vertex creation and scaling
- fix truncated geometry test

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches -- -D warnings`
- `cargo test --tests` *(fails: Exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_684dfcd321bc83318151a0d95e5b989f