### PR TITLE
Unify indicator lines color

### DIFF
--- a/DOCS/colors.md
+++ b/DOCS/colors.md
@@ -2,5 +2,6 @@
 
 - `e16c48` — sell color (used instead of red)
 - `74c787` — buy color (green)
+- `ffff00` — indicator lines (yellow)
 - `253242` — chart background
 - `283547` — page background

--- a/src/app.rs
+++ b/src/app.rs
@@ -1249,7 +1249,7 @@ async fn start_websocket_stream(chart: RwSignal<Chart>, set_status: WriteSignal<
 mod tests {
     use super::*;
     use crate::domain::chart::value_objects::ChartType;
-    use crate::domain::market_data::{Candle, OHLCV, Price, Timestamp, Volume};
+
     use wasm_bindgen::JsCast;
     use wasm_bindgen_test::*;
 

--- a/src/infrastructure/rendering/gpu_structures.rs
+++ b/src/infrastructure/rendering/gpu_structures.rs
@@ -263,11 +263,11 @@ impl ChartUniforms {
             bullish_color: [0.455, 0.780, 0.529, 1.0], // #74c787 - buy
             bearish_color: [0.882, 0.424, 0.282, 1.0], // #e16c48 - sell
             wick_color: [0.6, 0.6, 0.6, 1.0],          // gray
-            sma20_color: [1.0, 0.0, 0.0, 1.0],         // bright red
-            sma50_color: [1.0, 0.8, 0.0, 1.0],         // yellow
-            sma200_color: [0.2, 0.4, 0.8, 1.0],        // blue
-            ema12_color: [0.8, 0.2, 0.8, 1.0],         // violet
-            ema26_color: [0.0, 0.8, 0.8, 1.0],         // cyan
+            sma20_color: [1.0, 1.0, 0.0, 1.0],         // yellow
+            sma50_color: [1.0, 1.0, 0.0, 1.0],         // yellow
+            sma200_color: [1.0, 1.0, 0.0, 1.0],        // yellow
+            ema12_color: [1.0, 1.0, 0.0, 1.0],         // yellow
+            ema26_color: [1.0, 1.0, 0.0, 1.0],         // yellow
             current_price_color: [1.0, 1.0, 0.0, 0.8], // 💰 bright yellow with transparency
             render_params: [8.0, 2.0, 1.0, 0.0],       // width, spacing, line_width, padding
         }

--- a/src/infrastructure/rendering/renderer/geometry.rs
+++ b/src/infrastructure/rendering/renderer/geometry.rs
@@ -309,11 +309,11 @@ impl WebGpuRenderer {
             bullish_color: [0.455, 0.780, 0.529, 1.0], // #74c787 - green
             bearish_color: [0.882, 0.424, 0.282, 1.0], // #e16c48 - red
             wick_color: [0.6, 0.6, 0.6, 0.9],          // light gray
-            sma20_color: [1.0, 0.2, 0.2, 0.9],         // bright red
-            sma50_color: [1.0, 0.8, 0.0, 0.9],         // yellow
-            sma200_color: [0.2, 0.4, 0.8, 0.9],        // blue
-            ema12_color: [0.8, 0.2, 0.8, 0.9],         // purple
-            ema26_color: [0.0, 0.8, 0.8, 0.9],         // cyan
+            sma20_color: [1.0, 1.0, 0.0, 0.9],         // yellow
+            sma50_color: [1.0, 1.0, 0.0, 0.9],         // yellow
+            sma200_color: [1.0, 1.0, 0.0, 0.9],        // yellow
+            ema12_color: [1.0, 1.0, 0.0, 0.9],         // yellow
+            ema26_color: [1.0, 1.0, 0.0, 0.9],         // yellow
             current_price_color: [1.0, 1.0, 0.0, 0.8], // 💰 bright yellow
             render_params: [candle_width, spacing, 0.004, 0.0],
         };

--- a/src/infrastructure/rendering/renderer/mod.rs
+++ b/src/infrastructure/rendering/renderer/mod.rs
@@ -13,6 +13,7 @@ use crate::infrastructure::rendering::gpu_structures::{
 };
 use gloo::utils::document;
 use js_sys;
+use leptos::SignalSet;
 use std::cell::RefCell;
 use std::collections::VecDeque;
 use std::rc::Rc;
@@ -20,7 +21,6 @@ use wasm_bindgen::JsCast;
 use wasm_bindgen::JsValue;
 use web_sys::HtmlCanvasElement;
 use wgpu::util::DeviceExt;
-use leptos::SignalSet;
 thread_local! {
     static GLOBAL_RENDERER: RefCell<Option<Rc<RefCell<WebGpuRenderer>>>> = const { RefCell::new(None) };
 }

--- a/src/simple_shader.wgsl
+++ b/src/simple_shader.wgsl
@@ -53,18 +53,8 @@ fn vs_main(vertex: VertexInput) -> VertexOutput {
         // Candle wicks
         out.color = uniforms.wick_color; // gray
     } else if (vertex.element_type < 2.5) {
-        // Indicator lines
-        if (vertex.color_type < 2.5) {
-            out.color = uniforms.sma20_color; // SMA 20 - red
-        } else if (vertex.color_type < 3.5) {
-            out.color = uniforms.sma50_color; // SMA 50 - yellow
-        } else if (vertex.color_type < 4.5) {
-            out.color = uniforms.sma200_color; // SMA 200 - blue
-        } else if (vertex.color_type < 5.5) {
-            out.color = uniforms.ema12_color; // EMA 12 - purple
-        } else {
-            out.color = uniforms.ema26_color; // EMA 26 - cyan
-        }
+        // Indicator lines use the same yellow color
+        out.color = uniforms.sma20_color;
     } else if (vertex.element_type < 3.5) {
         // Chart grid
         out.color = vec4<f32>(0.3, 0.3, 0.3, 0.3); // semi-transparent gray

--- a/tests/geometry.rs
+++ b/tests/geometry.rs
@@ -101,6 +101,7 @@ fn corner_radius_ratio() {
     let corner = width * 0.15;
     let expected_x = x - width * 0.5 + corner;
     assert!((verts[0].position_x - expected_x).abs() < f32::EPSILON);
+}
 fn very_low_candle_no_rounding() {
     let low = CandleGeometry::create_candle_vertices(
         0.0, 1.0, 1.05, 0.95, 1.0, 0.0, 0.0, 0.05, -0.05, 0.0, 0.05,


### PR DESCRIPTION
## Summary
- document yellow indicator color
- use the yellow color for every indicator line
- simplify shader logic for indicator coloring

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`

------
https://chatgpt.com/codex/tasks/task_e_684dff5fd010833184b5a966d0a4f2ce