### PR TITLE
Fix constant price line width

### DIFF
--- a/src/infrastructure/rendering/renderer/geometry.rs
+++ b/src/infrastructure/rendering/renderer/geometry.rs
@@ -274,7 +274,8 @@ impl WebGpuRenderer {
             let price_y = ((current_price - min_price) / price_range) * 2.0 - 1.0; // same area as candles
 
             // Solid horizontal line across the entire screen
-            let line_thickness = 0.002;
+            // Keep the line width constant regardless of zoom level
+            let line_thickness = 2.0 / self.height as f32;
             let price_line = vec![
                 CandleVertex::current_price_vertex(-1.0, price_y - line_thickness),
                 CandleVertex::current_price_vertex(1.0, price_y - line_thickness),

--- a/tests/moving_average.rs
+++ b/tests/moving_average.rs
@@ -11,8 +11,6 @@ fn create_candle(close: f64, index: u64) -> Candle {
             Price::from(close),
             Price::from(close),
             Price::from(close),
-=======
-
             Volume::from(1.0),
         ),
     )
@@ -53,9 +51,12 @@ fn moving_averages_match_manual_calculation() {
     for (calc, exp) in ema5.iter().zip(expected_ema5.iter()) {
         assert!((calc.value() - exp).abs() < f64::EPSILON);
     }
+}
+
+#[wasm_bindgen_test]
 fn moving_average_short_input() {
     let svc = MarketAnalysisService::new();
-    let candles: Vec<Candle> = (0..3).map(make_candle).collect();
+    let candles: Vec<Candle> = (0..3).map(|i| create_candle(1.0, i)).collect();
 
     assert!(svc.calculate_sma(&candles, 5).is_empty());
     assert!(svc.calculate_ema(&candles, 5).is_empty());


### PR DESCRIPTION
## Summary
- ensure current price line stays 2px wide regardless of zoom level
- clean up `moving_average` test for formatting

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684e036182188331ae150ec3a9d35f37