### PR TITLE
maintain constant price line width

### DIFF
--- a/tests/moving_average.rs
+++ b/tests/moving_average.rs
@@ -11,8 +11,19 @@ fn create_candle(close: f64, index: u64) -> Candle {
             Price::from(close),
             Price::from(close),
             Price::from(close),
-=======
+            Volume::from(1.0),
+        ),
+    )
+}
 
+fn make_candle(i: u64) -> Candle {
+    Candle::new(
+        Timestamp::from_millis(i * 60_000),
+        OHLCV::new(
+            Price::from(1.0),
+            Price::from(1.0),
+            Price::from(1.0),
+            Price::from(1.0),
             Volume::from(1.0),
         ),
     )
@@ -53,6 +64,9 @@ fn moving_averages_match_manual_calculation() {
     for (calc, exp) in ema5.iter().zip(expected_ema5.iter()) {
         assert!((calc.value() - exp).abs() < f64::EPSILON);
     }
+}
+
+#[wasm_bindgen_test]
 fn moving_average_short_input() {
     let svc = MarketAnalysisService::new();
     let candles: Vec<Candle> = (0..3).map(make_candle).collect();


### PR DESCRIPTION
## Summary
- compute NDC units from pixels
- apply pixel based width for indicator and price lines
- update Ichimoku cloud width and test logic
- fix truncated moving average tests

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684e035d46408331a359a743091d87cc