### PR TITLE
Implement UTC time label formatting

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -31,6 +31,7 @@ use crate::{
         },
         websocket::BinanceWebSocketClient,
     },
+    time_utils::format_time_label,
 };
 
 /// Maximum number of candles visible at 1x zoom
@@ -453,14 +454,7 @@ fn TimeScale(chart: RwSignal<Chart>) -> impl IntoView {
                 candles.iter().skip(start_idx).nth(index.min(visible.saturating_sub(1)))
             {
                 let timestamp = candle.timestamp.value();
-                let date = js_sys::Date::new(&(timestamp as f64).into());
-                let time_str = if zoom >= 2.0 {
-                    format!("{:02}:{:02}", date.get_hours(), date.get_minutes())
-                } else if zoom >= 1.0 {
-                    format!("{:02}.{:02}", date.get_date(), date.get_month() + 1)
-                } else {
-                    format!("{:02}.{}", date.get_month() + 1, date.get_full_year())
-                };
+                let time_str = format_time_label(timestamp, zoom);
                 let position_percent = (i as f64 / (num_labels as f64 - 1.0)) * 100.0;
                 labels.push((time_str, position_percent));
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod domain;
 pub mod global_state;
 pub mod infrastructure;
 pub mod macros;
+pub mod time_utils;
 
 // === WASM EXPORTS ===
 use futures::lock::Mutex;

--- a/src/time_utils.rs
+++ b/src/time_utils.rs
@@ -1,0 +1,43 @@
+use js_sys::Date;
+use wasm_bindgen::JsValue;
+
+/// Format timestamp according to zoom level using UTC components.
+///
+/// - `zoom >= 2.0` -> `HH:MM`
+/// - `1.0 <= zoom < 2.0` -> `DD.MM`
+/// - `zoom < 1.0` -> `MM.YYYY`
+pub fn format_time_label(timestamp: u64, zoom: f64) -> String {
+    let date = Date::new(&JsValue::from_f64(timestamp as f64));
+    if zoom >= 2.0 {
+        format!("{:02}:{:02}", date.get_utc_hours(), date.get_utc_minutes())
+    } else if zoom >= 1.0 {
+        format!("{:02}.{:02}", date.get_utc_date(), date.get_utc_month() + 1)
+    } else {
+        format!("{:02}.{}", date.get_utc_month() + 1, date.get_utc_full_year())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_time_label;
+    use js_sys::Date;
+    use wasm_bindgen::JsValue;
+
+    #[test]
+    fn format_consistent_with_utc() {
+        let ts = 0u64;
+        let date = Date::new(&JsValue::from_f64(ts as f64));
+        assert_eq!(
+            format_time_label(ts, 2.0),
+            format!("{:02}:{:02}", date.get_utc_hours(), date.get_utc_minutes())
+        );
+        assert_eq!(
+            format_time_label(ts, 1.5),
+            format!("{:02}.{:02}", date.get_utc_date(), date.get_utc_month() + 1)
+        );
+        assert_eq!(
+            format_time_label(ts, 0.5),
+            format!("{:02}.{}", date.get_utc_month() + 1, date.get_utc_full_year())
+        );
+    }
+}

--- a/tests/time_label_format.rs
+++ b/tests/time_label_format.rs
@@ -1,0 +1,22 @@
+use js_sys::Date;
+use price_chart_wasm::time_utils::format_time_label;
+use wasm_bindgen::JsValue;
+use wasm_bindgen_test::*;
+
+#[wasm_bindgen_test]
+fn format_time_label_utc() {
+    let ts = 0u64; // 1970-01-01 00:00:00 UTC
+    let date = Date::new(&JsValue::from_f64(ts as f64));
+    assert_eq!(
+        format_time_label(ts, 2.0),
+        format!("{:02}:{:02}", date.get_utc_hours(), date.get_utc_minutes())
+    );
+    assert_eq!(
+        format_time_label(ts, 1.0),
+        format!("{:02}.{:02}", date.get_utc_date(), date.get_utc_month() + 1)
+    );
+    assert_eq!(
+        format_time_label(ts, 0.5),
+        format!("{:02}.{}", date.get_utc_month() + 1, date.get_utc_full_year())
+    );
+}

--- a/tests/time_scale_sync.rs
+++ b/tests/time_scale_sync.rs
@@ -3,7 +3,7 @@ use price_chart_wasm::domain::chart::{Chart, value_objects::ChartType};
 use price_chart_wasm::domain::market_data::{
     Candle, OHLCV, Price, TimeInterval, Timestamp, Volume,
 };
-use wasm_bindgen::JsValue;
+use price_chart_wasm::time_utils::format_time_label;
 use wasm_bindgen_test::*;
 
 fn make_candle(i: u64) -> Candle {
@@ -40,14 +40,7 @@ fn time_labels(chart: &Chart, zoom: f64) -> Vec<String> {
             candle_vec.iter().skip(start_idx).nth(index.min(visible.saturating_sub(1)))
         {
             let ts = candle.timestamp.value();
-            let date = js_sys::Date::new(&JsValue::from_f64(ts as f64));
-            let label = if zoom >= 2.0 {
-                format!("{:02}:{:02}", date.get_hours(), date.get_minutes())
-            } else if zoom >= 1.0 {
-                format!("{:02}.{:02}", date.get_date(), date.get_month() + 1)
-            } else {
-                format!("{:02}.{}", date.get_month() + 1, date.get_full_year())
-            };
+            let label = format_time_label(ts, zoom);
             labels.push(label);
         }
     }


### PR DESCRIPTION
## Summary
- add `format_time_label` for zoom-based UTC formatting
- use it in the app and tests
- verify UTC formatting with unit tests

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684e075555008331875b7b2b1d2797ea