### PR TITLE
Implement indicator color mapping

### DIFF
--- a/src/simple_shader.wgsl
+++ b/src/simple_shader.wgsl
@@ -53,8 +53,20 @@ fn vs_main(vertex: VertexInput) -> VertexOutput {
         // Candle wicks
         out.color = uniforms.wick_color; // gray
     } else if (vertex.element_type < 2.5) {
-        // Indicator lines use the same yellow color
-        out.color = uniforms.sma20_color;
+        // Indicator lines with dedicated colors
+        if (vertex.color_type < 2.5) {
+            out.color = uniforms.sma20_color;
+        } else if (vertex.color_type < 3.5) {
+            out.color = uniforms.sma50_color;
+        } else if (vertex.color_type < 4.5) {
+            out.color = uniforms.sma200_color;
+        } else if (vertex.color_type < 5.5) {
+            out.color = uniforms.ema12_color;
+        } else if (vertex.color_type < 6.5) {
+            out.color = uniforms.ema26_color;
+        } else {
+            out.color = vec4<f32>(1.0, 1.0, 1.0, 1.0);
+        }
     } else if (vertex.element_type < 3.5) {
         // Chart grid
         out.color = vec4<f32>(0.3, 0.3, 0.3, 0.3); // semi-transparent gray

--- a/tests/indicator_vertices.rs
+++ b/tests/indicator_vertices.rs
@@ -23,6 +23,25 @@ fn indicator_line_vertex_count() {
 }
 
 #[wasm_bindgen_test]
+fn indicator_line_color_types() {
+    let pts = [(-1.0, 0.0), (1.0, 1.0)];
+    let checks = [
+        (IndicatorType::SMA20, 2.0),
+        (IndicatorType::SMA50, 3.0),
+        (IndicatorType::SMA200, 4.0),
+        (IndicatorType::EMA12, 5.0),
+        (IndicatorType::EMA26, 6.0),
+    ];
+
+    for (t, c) in checks {
+        let verts = CandleGeometry::create_indicator_line_vertices(&pts, t, 0.1);
+        for v in verts {
+            assert!((v.color_type - c).abs() < f32::EPSILON);
+        }
+    }
+}
+
+#[wasm_bindgen_test]
 fn ichimoku_cloud_vertices() {
     let span_a = [(-1.0, 0.6), (0.0, 0.7), (1.0, 0.6)];
     let span_b = [(-1.0, 0.4), (0.0, 0.3), (1.0, 0.4)];


### PR DESCRIPTION
## Summary
- update WGSL shader to map indicator `color_type` to specific uniform colors
- ensure `CandleVertex::indicator_vertex` uses the correct `color_type`
- test that each indicator line receives its own color

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684e112edb50833198a63de69da34670