### PR TITLE
Add EDGE_GAP constant and adjust candle positioning

### DIFF
--- a/DOCS/VOLUME_SYNC_FIXES.md
+++ b/DOCS/VOLUME_SYNC_FIXES.md
@@ -48,7 +48,7 @@ Analysis of `src/infrastructure/rendering/renderer/geometry.rs` revealed:
 After the fixes:
 - ✅ Volume bars and candles use **identical positioning logic**
 - ✅ Volume bars and candles have **equal width** at the same zoom level
-- ✅ The last volume bars and candles are **exactly aligned to the right edge** (x=1.0)
+- ✅ The last volume bars and candles are **exactly aligned to the right edge** (x=1.0 - EDGE_GAP)
 - ✅ All chart elements are **synchronized** and aligned
 
 ## 🔧 Summary Table
@@ -59,7 +59,7 @@ After the fixes:
 | **Width calc**  | ❌ Different logic  | ✅ Same logic          |
 | **Bounds**      | ❌ Volume: only min | ✅ Volume: min+max     |
 | **Logging**     | ❌ `visible_count`  | ✅ `visible_candles.len()` |
-| **Right edge**  | ✅ x=1.0            | ✅ x=1.0               |
+| **Right edge**  | ✅ x=1.0            | ✅ x=1.0 - EDGE_GAP    |
 
 ## 📊 Covered Scenarios
 - Various zoom levels (0.2x - 32x)

--- a/src/app.rs
+++ b/src/app.rs
@@ -23,7 +23,9 @@ use crate::{
             value_objects::{Symbol, default_symbols},
         },
     },
-    infrastructure::rendering::renderer::LineVisibility,
+    infrastructure::rendering::renderer::{
+        EDGE_GAP, LineVisibility, MAX_ELEMENT_WIDTH, MIN_ELEMENT_WIDTH, spacing_ratio_for,
+    },
     infrastructure::{
         rendering::{
             WebGpuRenderer,
@@ -660,9 +662,15 @@ fn ChartContainer() -> impl IntoView {
 
                         // Use the same logic as in candle_x_position
                         let step_size = 2.0 / visible.len() as f64;
-                        // Inverse formula: if x = 1.0 - (visible_len - index - 1) * step_size
-                        // then index = visible_len - (1.0 - x) / step_size - 1
-                        let index_float = visible.len() as f64 - (1.0 - ndc_x) / step_size - 1.0;
+                        let spacing = spacing_ratio_for(visible.len()) as f64;
+                        let width = (step_size * (1.0 - spacing))
+                            .clamp(MIN_ELEMENT_WIDTH as f64, MAX_ELEMENT_WIDTH as f64);
+                        let half_width = width / 2.0;
+                        // Inverse formula matching candle_x_position
+                        // index = visible_len - 1 - (1.0 - EDGE_GAP as f64 - half_width - ndc_x) / step_size
+                        let index_float = visible.len() as f64
+                            - 1.0
+                            - (1.0 - EDGE_GAP as f64 - half_width - ndc_x) / step_size;
                         let candle_idx = index_float.round() as i32;
 
                         if candle_idx >= 0 && (candle_idx as usize) < visible.len() {

--- a/src/infrastructure/rendering/renderer/geometry.rs
+++ b/src/infrastructure/rendering/renderer/geometry.rs
@@ -13,6 +13,8 @@ pub const MIN_ELEMENT_WIDTH: f32 = 0.002;
 pub const MAX_ELEMENT_WIDTH: f32 = 0.1;
 /// Ratio of space left empty between elements
 pub const SPACING_RATIO: f32 = 0.2;
+/// Gap between the right edge and the last element
+pub const EDGE_GAP: f32 = 0.01;
 
 /// Dynamic spacing based on number of visible candles
 pub fn spacing_ratio_for(visible_len: usize) -> f32 {
@@ -25,9 +27,10 @@ pub fn spacing_ratio_for(visible_len: usize) -> f32 {
 pub fn candle_x_position(index: usize, visible_len: usize) -> f32 {
     assert!(visible_len > 0, "visible_len must be > 0");
     let step_size = 2.0 / visible_len as f32;
-    // Snap last candle exactly to the right edge (x=1.0)
-    // First candle will be at (1.0 - (visible_len-1) * step_size)
-    1.0 - (visible_len as f32 - index as f32 - 1.0) * step_size
+    let spacing = spacing_ratio_for(visible_len);
+    let width = (step_size * (1.0 - spacing)).clamp(MIN_ELEMENT_WIDTH, MAX_ELEMENT_WIDTH);
+    let base_x = 1.0 - (visible_len as f32 - index as f32 - 1.0) * step_size;
+    base_x - width / 2.0 - EDGE_GAP
 }
 
 impl WebGpuRenderer {

--- a/src/infrastructure/rendering/renderer/mod.rs
+++ b/src/infrastructure/rendering/renderer/mod.rs
@@ -110,7 +110,8 @@ impl Default for LineVisibility {
 
 mod geometry;
 pub use geometry::{
-    MAX_ELEMENT_WIDTH, MIN_ELEMENT_WIDTH, SPACING_RATIO, candle_x_position, spacing_ratio_for,
+    EDGE_GAP, MAX_ELEMENT_WIDTH, MIN_ELEMENT_WIDTH, SPACING_RATIO, candle_x_position,
+    spacing_ratio_for,
 };
 mod initialization;
 mod performance;

--- a/tests/README.md
+++ b/tests/README.md
@@ -5,7 +5,7 @@ This test set covers fixes for right-edge alignment and synchronization of all c
 ## Covered Fixes
 
 ### 1. **Right edge alignment** (`candle_x_position`)
-- ✅ Last candle exactly at `x=1.0`
+- ✅ Last candle exactly at `1.0 - EDGE_GAP`
 - ✅ Even candle spacing
 - ✅ Monotonic position increase
 
@@ -73,12 +73,15 @@ wasm-pack test --chrome --headless
 ### ✅ Right edge alignment
 ```rust
 let last_x = candle_x_position(visible_len - 1, visible_len);
-assert_eq!(last_x, 1.0); // Exactly on the right
+let step = 2.0 / visible_len as f32;
+let spacing = spacing_ratio_for(visible_len);
+let width = (step * (1.0 - spacing)).clamp(MIN_ELEMENT_WIDTH, MAX_ELEMENT_WIDTH);
+assert!((last_x + width / 2.0 + EDGE_GAP - 1.0).abs() < f32::EPSILON);
 ```
 
 ### ✅ Tooltip synchronization
 ```rust
-let index_float = visible_len as f64 - (1.0 - ndc_x) / step_size - 1.0;
+let index_float = visible_len as f64 - 1.0 - (1.0 - EDGE_GAP - half_width - ndc_x) / step_size;
 let calculated_index = index_float.round() as i32;
 assert_eq!(calculated_index as usize, expected_index);
 ```

--- a/tests/tooltip_positioning.rs
+++ b/tests/tooltip_positioning.rs
@@ -1,4 +1,6 @@
-use price_chart_wasm::infrastructure::rendering::renderer::candle_x_position;
+use price_chart_wasm::infrastructure::rendering::renderer::{
+    EDGE_GAP, MAX_ELEMENT_WIDTH, MIN_ELEMENT_WIDTH, candle_x_position, spacing_ratio_for,
+};
 use wasm_bindgen_test::*;
 
 #[wasm_bindgen_test]
@@ -12,7 +14,12 @@ fn tooltip_reverse_positioning() {
 
         // Apply the reverse formula (as in tooltip logic)
         let step_size = 2.0 / visible_len as f64;
-        let calculated_index = visible_len as f64 - (1.0 - x as f64) / step_size - 1.0;
+        let spacing = spacing_ratio_for(visible_len) as f64;
+        let width =
+            (step_size * (1.0 - spacing)).clamp(MIN_ELEMENT_WIDTH as f64, MAX_ELEMENT_WIDTH as f64);
+        let half_width = width / 2.0;
+        let calculated_index =
+            visible_len as f64 - 1.0 - (1.0 - EDGE_GAP as f64 - half_width - x as f64) / step_size;
         let rounded_index = calculated_index.round() as usize;
 
         // Verify we obtained the same index
@@ -28,17 +35,24 @@ fn tooltip_reverse_positioning() {
 fn tooltip_mouse_boundaries() {
     let visible_len = 5;
     let step_size = 2.0 / visible_len as f64;
+    let spacing = spacing_ratio_for(visible_len) as f64;
+    let width =
+        (step_size * (1.0 - spacing)).clamp(MIN_ELEMENT_WIDTH as f64, MAX_ELEMENT_WIDTH as f64);
+    let half_width = width / 2.0;
 
     // Test extreme coordinates
 
     // Left boundary should return index 0 or negative
     let left_boundary = -1.0;
-    let left_index = visible_len as f64 - (1.0 - left_boundary) / step_size - 1.0;
+    let left_index =
+        visible_len as f64 - 1.0 - (1.0 - EDGE_GAP as f64 - half_width - left_boundary) / step_size;
     assert!(left_index <= 0.0, "Left boundary should give index <= 0, got {}", left_index);
 
     // Right boundary should return the last index or higher
     let right_boundary = 1.0;
-    let right_index = visible_len as f64 - (1.0 - right_boundary) / step_size - 1.0;
+    let right_index = visible_len as f64
+        - 1.0
+        - (1.0 - EDGE_GAP as f64 - half_width - right_boundary) / step_size;
     assert!(
         right_index >= (visible_len - 1) as f64,
         "Right boundary should give index >= {}, got {}",
@@ -54,6 +68,10 @@ fn tooltip_positioning_consistency() {
 
     for &visible_len in &test_cases {
         let step_size = 2.0 / visible_len as f64;
+        let spacing = spacing_ratio_for(visible_len) as f64;
+        let width =
+            (step_size * (1.0 - spacing)).clamp(MIN_ELEMENT_WIDTH as f64, MAX_ELEMENT_WIDTH as f64);
+        let half_width = width / 2.0;
 
         // For each candle check that tooltip finds the correct index
         for expected_index in 0..visible_len {
@@ -63,7 +81,8 @@ fn tooltip_positioning_consistency() {
             let ndc_x = candle_x as f64;
 
             // Apply logic from app.rs
-            let index_float = visible_len as f64 - (1.0 - ndc_x) / step_size - 1.0;
+            let index_float =
+                visible_len as f64 - 1.0 - (1.0 - EDGE_GAP as f64 - half_width - ndc_x) / step_size;
             let calculated_index = index_float.round() as i32;
 
             // Ensure index is within bounds and correct


### PR DESCRIPTION
## Summary
- introduce `EDGE_GAP` constant
- adjust `candle_x_position` and tooltip formula
- update tests for new right edge location
- document new boundary at `1.0 - EDGE_GAP`

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684e0ff8caa08331b83eeec7ec34ece3