### PR TITLE
Remove 30m timeframe

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -973,7 +973,6 @@ fn TimeframeSelector(chart: RwSignal<Chart>) -> impl IntoView {
         TimeInterval::OneMinute,
         TimeInterval::FiveMinutes,
         TimeInterval::FifteenMinutes,
-        TimeInterval::ThirtyMinutes,
         TimeInterval::OneHour,
     ];
 
@@ -1282,9 +1281,9 @@ mod tests {
         fifteen.click();
         assert_eq!(current_interval().get(), TimeInterval::FifteenMinutes);
 
-        let thirty = find_button(&container, "30m");
-        thirty.click();
-        assert_eq!(current_interval().get(), TimeInterval::ThirtyMinutes);
+        let one_hour = find_button(&container, "1h");
+        one_hour.click();
+        assert_eq!(current_interval().get(), TimeInterval::OneHour);
     }
 
     #[wasm_bindgen_test]

--- a/src/domain/chart/entities.rs
+++ b/src/domain/chart/entities.rs
@@ -20,7 +20,6 @@ impl Chart {
         series.insert(TimeInterval::OneMinute, CandleSeries::new(max_candles));
         series.insert(TimeInterval::FiveMinutes, CandleSeries::new(max_candles));
         series.insert(TimeInterval::FifteenMinutes, CandleSeries::new(max_candles));
-        series.insert(TimeInterval::ThirtyMinutes, CandleSeries::new(max_candles));
         series.insert(TimeInterval::OneHour, CandleSeries::new(max_candles));
         series.insert(TimeInterval::OneDay, CandleSeries::new(max_candles));
         series.insert(TimeInterval::OneWeek, CandleSeries::new(max_candles));
@@ -173,7 +172,6 @@ impl Chart {
         let intervals = [
             TimeInterval::FiveMinutes,
             TimeInterval::FifteenMinutes,
-            TimeInterval::ThirtyMinutes,
             TimeInterval::OneHour,
             TimeInterval::OneDay,
             TimeInterval::OneWeek,

--- a/src/domain/market_data/value_objects.rs
+++ b/src/domain/market_data/value_objects.rs
@@ -152,9 +152,6 @@ pub fn default_symbols() -> Vec<Symbol> {
     Deserialize,
 )]
 pub enum TimeInterval {
-    #[strum(serialize = "30m")]
-    #[serde(rename = "30m")]
-    ThirtyMinutes,
     #[strum(serialize = "1m")]
     #[serde(rename = "1m")]
     OneMinute,
@@ -198,7 +195,6 @@ impl TimeInterval {
             Self::OneMinute => 60 * 1000,
             Self::FiveMinutes => 5 * 60 * 1000,
             Self::FifteenMinutes => 15 * 60 * 1000,
-            Self::ThirtyMinutes => 30 * 60 * 1000,
             Self::OneHour => 60 * 60 * 1000,
             Self::FourHours => 4 * 60 * 60 * 1000,
             Self::OneDay => 24 * 60 * 60 * 1000,

--- a/tests/aggregator.rs
+++ b/tests/aggregator.rs
@@ -46,18 +46,3 @@ fn aggregates_fifteen_minutes() {
     assert!((aggregated.ohlcv.low.value() - 95.0).abs() < f64::EPSILON);
     assert!((aggregated.ohlcv.volume.value() - 15.0).abs() < f64::EPSILON);
 }
-
-#[wasm_bindgen_test]
-fn aggregates_thirty_minutes() {
-    let candles: Vec<Candle> =
-        (0..30).map(|i| minute_candle(i * 60_000, 100.0 + i as f64)).collect();
-
-    let aggregated = Aggregator::aggregate(&candles, TimeInterval::ThirtyMinutes).unwrap();
-
-    assert_eq!(aggregated.timestamp.value(), 0);
-    assert!((aggregated.ohlcv.open.value() - 100.0).abs() < f64::EPSILON);
-    assert!((aggregated.ohlcv.close.value() - 130.0).abs() < f64::EPSILON);
-    assert!((aggregated.ohlcv.high.value() - 134.0).abs() < f64::EPSILON);
-    assert!((aggregated.ohlcv.low.value() - 95.0).abs() < f64::EPSILON);
-    assert!((aggregated.ohlcv.volume.value() - 30.0).abs() < f64::EPSILON);
-}


### PR DESCRIPTION
## Summary
- drop the unused 30-minute timeframe
- keep interval buttons for 1m, 5m, 15m and 1h only

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684e0f29d8c483319be5c13ce6de5d26