### PR TITLE
Add multi-symbol charts

### DIFF
--- a/tests/abort_handle.rs
+++ b/tests/abort_handle.rs
@@ -1,7 +1,8 @@
 use futures::future::{AbortHandle, Abortable};
 use gloo_timers::future::sleep;
 use leptos::*;
-use price_chart_wasm::app::stream_abort_handle;
+use price_chart_wasm::app::{current_symbol, stream_abort_handles};
+use price_chart_wasm::domain::market_data::Symbol;
 use std::time::Duration;
 use wasm_bindgen_test::*;
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
@@ -9,7 +10,10 @@ wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 #[wasm_bindgen_test(async)]
 async fn aborts_previous_stream() {
     let (handle, reg) = AbortHandle::new_pair();
-    stream_abort_handle().set(Some(handle.clone()));
+    current_symbol().set(Symbol::from("BTCUSDT"));
+    stream_abort_handles().update(|m| {
+        m.insert(Symbol::from("BTCUSDT"), handle.clone());
+    });
     let fut = Abortable::new(sleep(Duration::from_millis(50)), reg);
     handle.abort();
     assert!(fut.await.is_err());

--- a/tests/multi_symbol.rs
+++ b/tests/multi_symbol.rs
@@ -1,0 +1,40 @@
+use leptos::*;
+use price_chart_wasm::domain::market_data::{Candle, OHLCV, Price, Symbol, Timestamp, Volume};
+use price_chart_wasm::global_state::{ensure_chart, global_charts};
+use std::collections::HashMap;
+
+#[test]
+fn charts_accumulate_independently() {
+    global_charts().set(HashMap::new());
+    let btc = Symbol::from("BTCUSDT");
+    let eth = Symbol::from("ETHUSDT");
+    let btc_chart = ensure_chart(&btc);
+    let eth_chart = ensure_chart(&eth);
+
+    let candle_btc = Candle::new(
+        Timestamp::from_millis(0),
+        OHLCV::new(
+            Price::from(1.0),
+            Price::from(1.0),
+            Price::from(1.0),
+            Price::from(1.0),
+            Volume::from(1.0),
+        ),
+    );
+    btc_chart.update(|ch| ch.add_candle(candle_btc));
+
+    let candle_eth = Candle::new(
+        Timestamp::from_millis(60_000),
+        OHLCV::new(
+            Price::from(2.0),
+            Price::from(2.0),
+            Price::from(2.0),
+            Price::from(2.0),
+            Volume::from(2.0),
+        ),
+    );
+    eth_chart.update(|ch| ch.add_candle(candle_eth));
+
+    assert_eq!(btc_chart.with(|c| c.get_candle_count()), 1);
+    assert_eq!(eth_chart.with(|c| c.get_candle_count()), 1);
+}


### PR DESCRIPTION
## Summary
- store charts per symbol and track stream handles
- switch assets without stopping other streams
- adjust websocket startup for symbol map
- test that charts gather data independently

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`

------
https://chatgpt.com/codex/tasks/task_e_684e868bd0208331850dfcb7d9a7a6b8