### PR TITLE
Fix stream abort on symbol change

### DIFF
--- a/tests/switch_symbol_abort.rs
+++ b/tests/switch_symbol_abort.rs
@@ -1,0 +1,25 @@
+use futures::future::{AbortHandle, Abortable};
+use gloo_timers::future::sleep;
+use leptos::*;
+use price_chart_wasm::app::{abort_other_streams, current_symbol, stream_abort_handles};
+use price_chart_wasm::domain::market_data::Symbol;
+use std::time::Duration;
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[wasm_bindgen_test(async)]
+async fn aborts_old_stream_on_symbol_change() {
+    let (handle, reg) = AbortHandle::new_pair();
+    current_symbol().set(Symbol::from("BTCUSDT"));
+    stream_abort_handles().update(|m| {
+        m.insert(Symbol::from("BTCUSDT"), handle.clone());
+    });
+    let fut = Abortable::new(sleep(Duration::from_millis(50)), reg);
+
+    let new_symbol = Symbol::from("ETHUSDT");
+    abort_other_streams(&new_symbol);
+
+    assert!(fut.await.is_err());
+    assert!(stream_abort_handles().with(|m| !m.contains_key(&Symbol::from("BTCUSDT"))));
+}


### PR DESCRIPTION
## Summary
- manage WebSocket abort handles when changing symbol
- abort running streams during cleanup
- test handle removal on symbol switch

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684e94bb572883319239b0cc54786169