### PR TITLE
Remove SRI checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,14 @@ When using Trunk, open **`index.html`** (served automatically when using `trunk 
 
 ```html
 <!-- Trunk will automatically inject the WASM here -->
+
 <link data-trunk rel="rust" data-wasm-opt="z" />
 ```
+
+### Subresource Integrity
+
+This demo intentionally omits Subresource Integrity checks in HTML files to
+speed up deployments.
 
 ## Building with wasm-pack
 

--- a/dist/index.html
+++ b/dist/index.html
@@ -36,7 +36,7 @@
             100% { transform: rotate(360deg); }
         }
     </style>
-<link rel="modulepreload" href="/webgpu-candles/price-chart-wasm.js" crossorigin="anonymous" integrity="sha384-/HkzyKp3OdEWA3e3wZCgU7ckC57AM5bUJlXYujVm6kzpq1SNNeDSdIfyspsyVbR9"><link rel="preload" href="/webgpu-candles/price-chart-wasm_bg.wasm" crossorigin="anonymous" integrity="sha384-RGlz2nEb9PaX9JnKJOv6sz5boRNvmH1aDZEAmZYfoMDBDCL3O1CtXyacSZkIwUab" as="fetch" type="application/wasm"></head>
+<link rel="modulepreload" href="/webgpu-candles/price-chart-wasm.js" crossorigin="anonymous"><link rel="preload" href="/webgpu-candles/price-chart-wasm_bg.wasm" crossorigin="anonymous" as="fetch" type="application/wasm"></head>
 <body>
     <!-- Loading screen -->
     <div id="loading">

--- a/docs/dev/index.html
+++ b/docs/dev/index.html
@@ -36,7 +36,7 @@
             100% { transform: rotate(360deg); }
         }
     </style>
-<link rel="modulepreload" href="/webgpu-candles/price-chart-wasm.js" crossorigin="anonymous" integrity="sha384-/HkzyKp3OdEWA3e3wZCgU7ckC57AM5bUJlXYujVm6kzpq1SNNeDSdIfyspsyVbR9"><link rel="preload" href="/webgpu-candles/price-chart-wasm_bg.wasm" crossorigin="anonymous" integrity="sha384-RGlz2nEb9PaX9JnKJOv6sz5boRNvmH1aDZEAmZYfoMDBDCL3O1CtXyacSZkIwUab" as="fetch" type="application/wasm"></head>
+<link rel="modulepreload" href="/webgpu-candles/price-chart-wasm.js" crossorigin="anonymous"><link rel="preload" href="/webgpu-candles/price-chart-wasm_bg.wasm" crossorigin="anonymous" as="fetch" type="application/wasm"></head>
 <body>
     <!-- Loading screen -->
     <div id="loading">


### PR DESCRIPTION
## Summary
- drop integrity attribute from HTML files
- note that integrity checks are disabled

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684e958d70e88331b01db3e828364ccd