### PR TITLE
Fix chart bounds

### DIFF
--- a/src/infrastructure/rendering/renderer/geometry.rs
+++ b/src/infrastructure/rendering/renderer/geometry.rs
@@ -14,7 +14,7 @@ pub const MAX_ELEMENT_WIDTH: f32 = 0.1;
 /// Ratio of space left empty between elements
 pub const SPACING_RATIO: f32 = 0.2;
 /// Gap between the right edge and the last element
-pub const EDGE_GAP: f32 = 0.01;
+pub const EDGE_GAP: f32 = 0.003;
 
 /// Dynamic spacing based on number of visible candles
 pub fn spacing_ratio_for(visible_len: usize) -> f32 {


### PR DESCRIPTION
## Summary
- tweak EDGE_GAP so first candle stays inside the viewport

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`
- `cargo test --test chart_positioning -- --nocapture` *(fails: Exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_684e99cb5be883318c8d35f6b8a6146b