### PR TITLE
Set snapshot path env variable in geometry test

### DIFF
--- a/tests/geometry.rs
+++ b/tests/geometry.rs
@@ -59,6 +59,9 @@ fn candle_geometry_snapshot() {
         );
     }
 
+    unsafe {
+        std::env::set_var("INSTA_WORKSPACE_ROOT", env!("CARGO_MANIFEST_DIR"));
+    }
     with_settings!({snapshot_path => "tests/fixtures"}, {
         assert_json_snapshot!("candle_vertices", result);
     });


### PR DESCRIPTION
## Summary
- set `INSTA_WORKSPACE_ROOT` before snapshot assertion in `geometry.rs`

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684ea271efb88331ba36acea0c7e7b50