### PR TITLE
Fix favicon paths

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>🦀 Crypto Chart - Leptos + WebGPU</title>
-    <link rel="icon" type="image/svg+xml" href="/res/favicon.svg">
-    <link rel="icon" type="image/png" href="/res/favicon.png">
+    <link rel="icon" type="image/svg+xml" href="res/favicon.svg">
+    <link rel="icon" type="image/png" href="res/favicon.png">
     <style>
         body {
             margin: 0;

--- a/docs/dev/index.html
+++ b/docs/dev/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>🦀 Crypto Chart - Leptos + WebGPU</title>
-    <link rel="icon" type="image/svg+xml" href="/res/favicon.svg">
-    <link rel="icon" type="image/png" href="/res/favicon.png">
+    <link rel="icon" type="image/svg+xml" href="res/favicon.svg">
+    <link rel="icon" type="image/png" href="res/favicon.png">
     <style>
         body {
             margin: 0;

--- a/index.html
+++ b/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>🦀 Crypto Chart - Leptos + WebGPU</title>
-    <link rel="icon" type="image/svg+xml" href="/res/favicon.svg">
-    <link rel="icon" type="image/png" href="/res/favicon.png">
+    <link rel="icon" type="image/svg+xml" href="res/favicon.svg">
+    <link rel="icon" type="image/png" href="res/favicon.png">
     <style>
         body {
             margin: 0;


### PR DESCRIPTION
## Summary
- use `res/` paths for favicons

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684ead909ec483318f2881f70d523f94