### PR TITLE
Fix dev HTML assets

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -38,7 +38,7 @@
             100% { transform: rotate(360deg); }
         }
     </style>
-<link rel="modulepreload" href="/webgpu-candles/price-chart-wasm.js" crossorigin="anonymous" integrity="sha384-Iw1zsoJFhJ0TLVYNIirfJ+XfeIfnLB11778liLk8QnO+AXEGMyvmQmqI7wmfpwT1"><link rel="preload" href="/webgpu-candles/price-chart-wasm_bg.wasm" crossorigin="anonymous" integrity="sha384-wVKUJ8/XzFvqlt/k62kB/fnR/aPXd6orvTE06FKwJaq+1vpMDyF2QD/vMWt+7v3g" as="fetch" type="application/wasm"></head>
+<link rel="modulepreload" href="/webgpu-candles/price-chart-wasm.js" crossorigin="anonymous"><link rel="preload" href="/webgpu-candles/price-chart-wasm_bg.wasm" crossorigin="anonymous" as="fetch" type="application/wasm"></head>
 <body>
     <!-- Loading screen -->
     <div id="loading">

--- a/docs/dev/index.html
+++ b/docs/dev/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>🦀 Crypto Chart - Leptos + WebGPU</title>
-    <link rel="icon" type="image/svg+xml" href="res/favicon.svg">
-    <link rel="icon" type="image/png" href="res/favicon.png">
+    <link rel="icon" type="image/svg+xml" href="../res/favicon.svg">
+    <link rel="icon" type="image/png" href="../res/favicon.png">
     <style>
         body {
             margin: 0;
@@ -38,7 +38,7 @@
             100% { transform: rotate(360deg); }
         }
     </style>
-<link rel="modulepreload" href="/webgpu-candles/price-chart-wasm.js" crossorigin="anonymous" integrity="sha384-Iw1zsoJFhJ0TLVYNIirfJ+XfeIfnLB11778liLk8QnO+AXEGMyvmQmqI7wmfpwT1"><link rel="preload" href="/webgpu-candles/price-chart-wasm_bg.wasm" crossorigin="anonymous" integrity="sha384-wVKUJ8/XzFvqlt/k62kB/fnR/aPXd6orvTE06FKwJaq+1vpMDyF2QD/vMWt+7v3g" as="fetch" type="application/wasm"></head>
+<link rel="modulepreload" href="/webgpu-candles/price-chart-wasm.js" crossorigin="anonymous"><link rel="preload" href="/webgpu-candles/price-chart-wasm_bg.wasm" crossorigin="anonymous" as="fetch" type="application/wasm"></head>
 <body>
     <!-- Loading screen -->
     <div id="loading">


### PR DESCRIPTION
## Summary
- remove integrity attributes from preloaded WASM modules
- fix favicon path for dev build

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684eb2a30a8083319e3e323775404fdb