### PR TITLE
Add no-SRI flag for Trunk builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Clean dist
         run: rm -rf dist
       - name: Build
-        run: trunk build --release --dist dist
+        run: trunk build --release --dist dist --no-sri
       - name: Save version
         run: echo ${{ github.sha }} > dist/version
       - name: Copy dist to docs/dev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Clean dist
         run: rm -rf dist
       - name: Build
-        run: trunk build --release --dist dist --public-url /webgpu-candles/
+        run: trunk build --release --dist dist --public-url /webgpu-candles/ --no-sri
       - name: Save version
         run: echo ${{ github.sha }} > dist/version
       - name: Copy dist to docs

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 COPY . .
 
 # Build the project with Trunk for production (Docker settings overridden)
-RUN trunk build --release --dist dist --public-url / && \
+RUN trunk build --release --dist dist --public-url / --no-sri && \
     git rev-parse HEAD > dist/version
 
 FROM nginx:alpine


### PR DESCRIPTION
## Summary
- add `--no-sri` to workflow build commands
- add the same flag to Dockerfile build step

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684ec70e431083318cb2a22503db11b1