### PR TITLE
Enable SRI in builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Clean dist
         run: rm -rf dist
       - name: Build
-        run: trunk build --release --dist dist --no-sri
+        run: trunk build --release --dist dist
       - name: Save version
         run: echo ${{ github.sha }} > dist/version
       - name: Copy dist to docs/dev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Clean dist
         run: rm -rf dist
       - name: Build
-        run: trunk build --release --dist dist --public-url /webgpu-candles/ --no-sri
+        run: trunk build --release --dist dist --public-url /webgpu-candles/
       - name: Save version
         run: echo ${{ github.sha }} > dist/version
       - name: Copy dist to docs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,6 @@
   - `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`
 - If your changes touch only Markdown files, you can skip the build checks above.
 - Do not mention these commands in commit messages.
-- Do not use `integrity` attributes in HTML files.
 - Running tests (e.g. `wasm-pack test`) won't work due to wasm; they will run in GitHub Actions.
 - One of the readiness criteria is the absence of formatting issues and linter warnings.
 - Do not suppress warnings about unused code via `#[allow(dead_code)]`. Remove dead code instead.

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 COPY . .
 
 # Build the project with Trunk for production (Docker settings overridden)
-RUN trunk build --release --dist dist --public-url / --no-sri && \
+RUN trunk build --release --dist dist --public-url / && \
     git rev-parse HEAD > dist/version
 
 FROM nginx:alpine

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ When using Trunk, open **`index.html`** (served automatically when using `trunk 
 
 ### Subresource Integrity
 
-This demo intentionally omits Subresource Integrity checks in HTML files to
-speed up deployments.
+Trunk automatically includes integrity hashes for the generated JavaScript
+and WebAssembly files.
 
 ## Building with wasm-pack
 


### PR DESCRIPTION
## Summary
- allow integrity hashes by removing AGENTS rule
- describe SRI in README
- enable SRI in Docker build
- enable SRI in CI workflows

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684eced2fe1c8331b5fec01942ebe6a4