### PR TITLE
Fix canvas init

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -500,15 +500,14 @@ fn ChartContainer() -> impl IntoView {
     let (initialized, set_initialized) = create_signal(false);
 
     // Initialize WebGPU when the canvas element becomes available
-    canvas_ref.on_load(move |_canvas| {
+    canvas_ref.on_load(move |canvas| {
         if initialized.get() {
             return;
         }
 
-        if let Some(canvas) = canvas_ref.get() {
-            let canvas_id = std::ops::Deref::deref(&canvas).id();
-            set_initialized.set(true);
-            let _ = spawn_local_with_current_owner(async move {
+        let canvas_id = std::ops::Deref::deref(&canvas).id();
+        set_initialized.set(true);
+        let _ = spawn_local_with_current_owner(async move {
                 web_sys::console::log_1(&"🔍 Canvas found, starting WebGPU init...".into());
                 set_status.set("🚀 Initializing WebGPU renderer...".to_string());
 
@@ -595,13 +594,6 @@ fn ChartContainer() -> impl IntoView {
                     }
                 }
             });
-        } else {
-            #[allow(clippy::needless_return)]
-            {
-                set_status.set("❌ Canvas element not found".to_string());
-                return;
-            }
-        }
     });
 
     // 🎯 Mouse events for the tooltip


### PR DESCRIPTION
## Summary
- use the canvas element passed to `on_load`

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684ed0d7b46c8331bc9043d40fcdb12f