### PR TITLE
Fix chart memo creation

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -487,9 +487,14 @@ fn TimeScale(chart: RwSignal<Chart>) -> impl IntoView {
 /// 🎨 Container for the WebGPU chart
 #[component]
 fn ChartContainer() -> impl IntoView {
+    ensure_chart(&current_symbol().get_untracked());
+    create_effect(move |_| {
+        let sym = current_symbol().get();
+        ensure_chart(&sym);
+    });
     let chart_memo = create_memo(move |_| {
         let sym = current_symbol().get();
-        ensure_chart(&sym)
+        global_charts().with(|m| m.get(&sym).copied().unwrap())
     });
     let chart = move || chart_memo.get();
     let (renderer, set_renderer) = create_signal::<Option<Rc<RefCell<WebGpuRenderer>>>>(None);


### PR DESCRIPTION
## Summary
- ensure chart initialization via effect
- avoid global state mutations inside `create_memo`

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684ee0c72e048331a9332aa36a03765a