### PR TITLE
Fix wheel event disposal

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -699,6 +699,9 @@ fn ChartContainer() -> impl IntoView {
         let chart_signal = chart;
         let status_clone = set_status;
         move |event: web_sys::WheelEvent| {
+            if chart_signal().try_get_untracked().is_none() {
+                return;
+            }
             web_sys::console::log_1(&format!("🖱️ Wheel event: delta_y={}", event.delta_y()).into());
             event.prevent_default();
 
@@ -839,6 +842,10 @@ fn ChartContainer() -> impl IntoView {
         }
     };
 
+    // Attach wheel event listener to the window
+    let wheel_listener = window_event_listener(ev::wheel, handle_wheel);
+    on_cleanup(move || wheel_listener.remove());
+
     // Zoom effect removed - handled directly in the wheel handler
 
     view! {
@@ -862,7 +869,6 @@ fn ChartContainer() -> impl IntoView {
                         style="border: 2px solid #4a5d73; border-radius: 10px; background: #253242; cursor: crosshair; outline: none;"
                         on:mousemove=handle_mouse_move
                         on:mouseleave=handle_mouse_leave
-                        on:wheel=handle_wheel
                         on:mousedown=handle_mouse_down
                         on:mouseup=handle_mouse_up
                         on:keydown=handle_keydown


### PR DESCRIPTION
## Summary
- avoid wheel event after component disposal by checking signal
- register wheel event on window with automatic cleanup

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`

------
https://chatgpt.com/codex/tasks/task_e_684ee0db70348331b920997bc28b8fea