### PR TITLE
Fix release workflow branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,4 +48,4 @@ jobs:
           git config user.email github-actions@github.com
           git add docs
           git commit -m "Update release build" || echo "No changes"
-          git push
+          git push origin HEAD:release


### PR DESCRIPTION
## Summary
- update release workflow to push built docs to the `release` branch

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684ef6fd94f88331b68b42f21771c5f9