### PR TITLE
auto-scroll latest candle

### DIFF
--- a/tests/auto_scroll.rs
+++ b/tests/auto_scroll.rs
@@ -1,0 +1,7 @@
+use price_chart_wasm::app::should_auto_scroll;
+
+#[test]
+fn detects_right_edge() {
+    assert!(should_auto_scroll(100, 2.0, 0.0));
+    assert!(!should_auto_scroll(100, 2.0, -1.0));
+}


### PR DESCRIPTION
## Summary
- auto scroll viewport when no candles remain on the right
- test auto scroll logic

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684f00573f2083318a870fdc9fb111a9