### PR TITLE
Fix dragging release handling

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -870,6 +870,13 @@ fn ChartContainer() -> impl IntoView {
     );
     on_cleanup(move || wheel_listener.remove());
 
+    // Reset dragging state when the mouse is released anywhere
+    let mouseup_listener =
+        window_event_listener_with_options(ev::mouseup, &EventOptions::default(), move |_| {
+            is_dragging().set(false)
+        });
+    on_cleanup(move || mouseup_listener.remove());
+
     // Zoom effect removed - handled directly in the wheel handler
 
     view! {


### PR DESCRIPTION
## Summary
- reset dragging on global mouseup

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684f05f6ab608331bc0e34ef7c2d5014