### PR TITLE
Fix release workflow push ref

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,4 +48,4 @@ jobs:
           git config user.email github-actions@github.com
           git add docs
           git commit -m "Update release build" || echo "No changes"
-          git push origin HEAD:release
+          git push origin HEAD:refs/heads/release


### PR DESCRIPTION
## Summary
- fix the ref pushed in release workflow

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684fc21fad0083319cfb1d6950dad128