### PR TITLE
Allow panning across entire history

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -66,7 +66,7 @@ pub fn visible_range(len: usize, zoom: f64, pan: f64) -> (usize, usize) {
     let visible = ((MAX_VISIBLE_CANDLES / zoom).max(MIN_VISIBLE_CANDLES).min(len as f64)) as isize;
     let base_start = len as isize - visible;
     let offset = pan.round() as isize;
-    let min_start = (base_start - HISTORY_BUFFER_SIZE as isize).max(0);
+    let min_start = 0;
     let max_start = len as isize - visible;
     let start = (base_start + offset).clamp(min_start, max_start);
     (start as usize, visible as usize)


### PR DESCRIPTION
## Summary
- remove history buffer clamp in `visible_range` so that users can pan to the earliest candle immediately

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684fdf2bbdfc8331859179c17ed0e129