### PR TITLE
Increase default candle count

### DIFF
--- a/src/global_state.rs
+++ b/src/global_state.rs
@@ -45,7 +45,7 @@ pub fn globals() -> &'static Globals {
         loading_more: create_rw_signal(false),
         tooltip_data: create_rw_signal(None),
         tooltip_visible: create_rw_signal(false),
-        zoom_level: create_rw_signal(1.0),
+        zoom_level: create_rw_signal(0.32),
         pan_offset: create_rw_signal(0.0),
         is_dragging: create_rw_signal(false),
         last_mouse_x: create_rw_signal(0.0),


### PR DESCRIPTION
## Summary
- increase default candle count on startup by lowering the initial zoom level

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684fde2cd9ac8331a33a98373df7b6c6