### PR TITLE
Remove zoom-based series selection

### DIFF
--- a/src/domain/chart/entities.rs
+++ b/src/domain/chart/entities.rs
@@ -152,23 +152,6 @@ impl Chart {
         self.series.get(&interval)
     }
 
-    pub fn get_series_for_zoom(&self, zoom: f64) -> &CandleSeries {
-        let interval = if zoom >= 4.0 {
-            TimeInterval::OneMinute
-        } else if zoom >= 2.0 {
-            TimeInterval::FiveMinutes
-        } else if zoom >= 1.0 {
-            TimeInterval::FifteenMinutes
-        } else {
-            TimeInterval::OneHour
-        };
-
-        self.series
-            .get(&interval)
-            .or_else(|| self.series.get(&TimeInterval::TwoSeconds))
-            .expect("base series not found")
-    }
-
     fn update_aggregates(&mut self, candle: Candle) {
         let intervals = [
             TimeInterval::OneMinute,

--- a/src/infrastructure/rendering/renderer/geometry.rs
+++ b/src/infrastructure/rendering/renderer/geometry.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::domain::logging::{LogComponent, get_logger};
-use crate::domain::market_data::Price;
 use crate::domain::market_data::services::MarketAnalysisService;
+use crate::domain::market_data::{Price, TimeInterval};
 use crate::infrastructure::rendering::gpu_structures::{
     CandleGeometry, CandleInstance, IndicatorType,
 };
@@ -46,10 +46,9 @@ impl WebGpuRenderer {
         use crate::app::current_interval;
 
         let interval = current_interval().get_untracked();
-        let candles = chart
-            .get_series(interval)
-            .map(|s| s.get_candles())
-            .unwrap_or_else(|| chart.get_series_for_zoom(self.zoom_level).get_candles());
+        let candles = chart.get_series(interval).map(|s| s.get_candles()).unwrap_or_else(|| {
+            chart.get_series(TimeInterval::TwoSeconds).expect("base series not found").get_candles()
+        });
 
         if candles.is_empty() {
             get_logger()

--- a/src/infrastructure/rendering/renderer/initialization.rs
+++ b/src/infrastructure/rendering/renderer/initialization.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::domain::market_data::TimeInterval;
 use leptos::SignalGetUntracked;
 use std::collections::VecDeque;
 
@@ -296,10 +297,9 @@ impl WebGpuRenderer {
         // Simplified update method - just store vertex count for debugging
         use crate::app::current_interval;
         let interval = current_interval().get_untracked();
-        let candles = chart
-            .get_series(interval)
-            .map(|s| s.get_candles())
-            .unwrap_or_else(|| chart.get_series_for_zoom(self.zoom_level).get_candles());
+        let candles = chart.get_series(interval).map(|s| s.get_candles()).unwrap_or_else(|| {
+            chart.get_series(TimeInterval::TwoSeconds).expect("base series not found").get_candles()
+        });
         get_logger().info(
             LogComponent::Infrastructure("WebGpuRenderer"),
             &format!("📊 Updated chart data: {} candles", candles.len()),


### PR DESCRIPTION
## Summary
- remove `get_series_for_zoom`
- use the current interval or the 2s base series in renderer

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`

------
https://chatgpt.com/codex/tasks/task_e_684fc26f79bc83319d66e27773226951