### PR TITLE
Remove unnecessary Insta env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,13 +140,6 @@ them with:
 wasm-pack test
 ```
 
-Snapshot tests rely on the `INSTA_WORKSPACE_ROOT` environment variable. Set it to the repository root when running locally:
-
-```bash
-# example
-INSTA_WORKSPACE_ROOT=$PWD wasm-pack test
-```
-
 Alternatively install Node dependencies and run:
 
 ```bash

--- a/tests/geometry.rs
+++ b/tests/geometry.rs
@@ -59,9 +59,8 @@ fn candle_geometry_snapshot() {
         );
     }
 
-    unsafe {
-        std::env::set_var("INSTA_WORKSPACE_ROOT", env!("CARGO_MANIFEST_DIR"));
-    }
+    #[cfg(not(target_arch = "wasm32"))]
+    std::env::set_var("INSTA_WORKSPACE_ROOT", env!("CARGO_MANIFEST_DIR"));
     with_settings!({snapshot_path => "tests/fixtures"}, {
         assert_json_snapshot!("candle_vertices", result);
     });


### PR DESCRIPTION
## Summary
- set INSTA_WORKSPACE_ROOT only when not building for `wasm32`
- drop README note about setting INSTA_WORKSPACE_ROOT

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_68517e1a6db483318a027a9b56cc3377