### PR TITLE
Add artifact uploads to bot

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -63,3 +63,8 @@ jobs:
         with:
           name: perf_results
           path: docs/perf_result.json
+      - name: Send benchmark results to bot
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        run: scripts/send_to_bot.sh docs/perf_result.json "Benchmark results"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,17 @@ jobs:
         run: trunk build --release --dist dist --public-url /webgpu-candles/dev/
       - name: Save version
         run: echo ${{ github.sha }} > dist/version
+      - name: Archive dist
+        run: tar -czf dist.tar.gz -C dist .
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist.tar.gz
+      - name: Send build to bot
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        run: scripts/send_to_bot.sh dist.tar.gz "Development build"
       - name: Copy dist to docs/dev
         run: |
           mkdir -p docs/dev

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -42,3 +42,8 @@ jobs:
         with:
           name: perf-log
           path: perf.log
+      - name: Send results to bot
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        run: scripts/send_to_bot.sh perf.log "Performance results"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,17 @@ jobs:
         run: trunk build --release --dist dist --public-url /webgpu-candles/
       - name: Save version
         run: echo ${{ github.sha }} > dist/version
+      - name: Archive dist
+        run: tar -czf dist.tar.gz -C dist .
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-dist
+          path: dist.tar.gz
+      - name: Send release to bot
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        run: scripts/send_to_bot.sh dist.tar.gz "Release build"
       - name: Copy dist to docs
         run: |
           cp -r dist/* docs/

--- a/scripts/send_to_bot.sh
+++ b/scripts/send_to_bot.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -lt 1 ]; then
+    echo "Usage: send_to_bot.sh FILE [MESSAGE]" >&2
+    exit 1
+fi
+
+file="$1"
+message="${2:-}"
+
+if [ -z "${TELEGRAM_BOT_TOKEN:-}" ] || [ -z "${TELEGRAM_CHAT_ID:-}" ]; then
+    echo "TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID must be set" >&2
+    exit 1
+fi
+
+curl -fsSL -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendDocument" \
+  -F chat_id="${TELEGRAM_CHAT_ID}" \
+  -F document=@"${file}" \
+  -F caption="${message}"


### PR DESCRIPTION
## Summary
- add `send_to_bot.sh` script for sending files to Telegram bot
- send artifacts to the bot from perf, benchmark, build and release workflows

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_68517d5bc0ec833185ed3136e909e91c