### PR TITLE
docs: add pipelines guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@
 - Markdown in the project must be consistent: use `#` for headers, specify languages for code blocks, and maintain clear structure.
 - Comments in the code and all documentation are written only in English.
 - A summary of available tests and snapshot locations is found in [TESTS.md](DOCS/TESTS.md).
+- The pipelines documentation resides in [PIPELINES.md](DOCS/PIPELINES.md).
 - Translate branch and task names into English even if they were originally given in Russian.
 - Branch names must be strictly in English; do not use Russian words or letters.
 - Always provide branch names and task titles in English, even if the original request is in Russian.

--- a/DOCS/PIPELINES.md
+++ b/DOCS/PIPELINES.md
@@ -1,0 +1,9 @@
+# GitHub Actions Pipelines
+
+This document outlines the CI pipelines used in this repository.
+
+- `build.yml` — compiles the project for multiple platforms.
+- `test.yml` — runs unit and integration tests.
+- `benchmark.yml` — measures performance against baseline.
+- `perf.yml` — tracks WebAssembly size and rendering speed.
+- `release.yml` — publishes release builds and artifacts.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ All additional documentation lives in the [`DOCS/`](DOCS/) directory:
 - [CONTRIBUTING.md](DOCS/CONTRIBUTING.md)
 - [PERFORMANCE.md](DOCS/PERFORMANCE.md)
 - [TESTS.md](DOCS/TESTS.md)
+- [PIPELINES.md](DOCS/PIPELINES.md)
 - [VOLUME_SYNC_FIXES.md](DOCS/VOLUME_SYNC_FIXES.md)
 - [COLORS.md](DOCS/COLORS.md)
 


### PR DESCRIPTION
## Summary
- document CI pipelines
- link new pipelines guide in README
- note location of pipelines doc in AGENTS

## Testing
- `cargo fmt --all`

------
https://chatgpt.com/codex/tasks/task_e_685180bf82288331a449b548530d861e