### PR TITLE
Remove global chart signals

### DIFF
--- a/src/ecs/components.rs
+++ b/src/ecs/components.rs
@@ -1,9 +1,10 @@
 use crate::domain::chart::{Chart, value_objects::Viewport};
 use crate::domain::market_data::Candle;
+use leptos::RwSignal;
 
-/// ECS component containing a complete trading chart.
-#[derive(Debug, Clone)]
-pub struct ChartComponent(pub Chart);
+/// ECS component containing a reactive trading chart.
+#[derive(Debug, Clone, Copy)]
+pub struct ChartComponent(pub RwSignal<Chart>);
 
 /// ECS component storing a single candle.
 #[derive(Debug, Clone)]

--- a/src/ecs/mod.rs
+++ b/src/ecs/mod.rs
@@ -19,7 +19,10 @@ impl EcsWorld {
     /// Spawn a new chart entity with its component.
     pub fn spawn_chart(&mut self, chart: crate::domain::chart::Chart) -> hecs::Entity {
         use crate::ecs::components::ChartComponent;
-        self.world.spawn((ChartComponent(chart),))
+        use leptos::create_rw_signal;
+
+        let signal = create_rw_signal(chart);
+        self.world.spawn((ChartComponent(signal),))
     }
 
     /// Apply all pending candle components to charts.

--- a/src/ecs/systems.rs
+++ b/src/ecs/systems.rs
@@ -1,6 +1,7 @@
 use hecs::World;
 
 use super::components::{CandleComponent, ChartComponent};
+use leptos::SignalUpdate;
 
 /// Apply new candles to all charts and remove processed candle entities.
 pub fn apply_candles(world: &mut World) {
@@ -14,7 +15,7 @@ pub fn apply_candles(world: &mut World) {
 
     for (_, candle) in &candles {
         for (_, chart) in world.query::<&mut ChartComponent>().iter() {
-            chart.0.add_realtime_candle(candle.0.clone());
+            chart.0.update(|c| c.add_realtime_candle(candle.0.clone()));
         }
     }
 

--- a/src/global_state.rs
+++ b/src/global_state.rs
@@ -9,7 +9,7 @@ use crate::domain::{
     chart::{Chart, value_objects::ChartType},
     market_data::{Candle, Symbol, TimeInterval},
 };
-use crate::ecs::{components::ChartComponent, EcsWorld};
+use crate::ecs::{EcsWorld, components::ChartComponent};
 use futures::future::AbortHandle;
 use leptos::*;
 use once_cell::sync::OnceCell;
@@ -64,7 +64,6 @@ pub fn globals() -> &'static Globals {
 pub fn ecs_world() -> &'static Mutex<EcsWorld> {
     ECS_WORLD.get_or_init(|| Mutex::new(EcsWorld::new()))
 }
-
 
 pub fn get_chart_signal(symbol: &Symbol) -> Option<RwSignal<Chart>> {
     let world = ecs_world().lock().unwrap();

--- a/src/global_state.rs
+++ b/src/global_state.rs
@@ -9,7 +9,7 @@ use crate::domain::{
     chart::{Chart, value_objects::ChartType},
     market_data::{Candle, Symbol, TimeInterval},
 };
-use crate::ecs::EcsWorld;
+use crate::ecs::{components::ChartComponent, EcsWorld};
 use futures::future::AbortHandle;
 use leptos::*;
 use once_cell::sync::OnceCell;
@@ -30,7 +30,6 @@ pub struct Globals {
     pub last_mouse_x: RwSignal<f64>,
     pub current_interval: RwSignal<TimeInterval>,
     pub current_symbol: RwSignal<Symbol>,
-    pub charts: RwSignal<HashMap<Symbol, RwSignal<Chart>>>,
     pub stream_abort_handles: RwSignal<HashMap<Symbol, AbortHandle>>,
     pub line_visibility: RwSignal<crate::infrastructure::rendering::renderer::LineVisibility>,
 }
@@ -54,7 +53,6 @@ pub fn globals() -> &'static Globals {
         last_mouse_x: create_rw_signal(0.0),
         current_interval: create_rw_signal(TimeInterval::OneMinute),
         current_symbol: create_rw_signal(Symbol::from("BTCUSDT")),
-        charts: create_rw_signal(HashMap::new()),
         stream_abort_handles: create_rw_signal(HashMap::new()),
         line_visibility: create_rw_signal(
             crate::infrastructure::rendering::renderer::LineVisibility::default(),
@@ -67,20 +65,25 @@ pub fn ecs_world() -> &'static Mutex<EcsWorld> {
     ECS_WORLD.get_or_init(|| Mutex::new(EcsWorld::new()))
 }
 
-pub fn ensure_chart(symbol: &Symbol) -> RwSignal<Chart> {
-    let charts = &globals().charts;
-    charts.update(|map| {
-        map.entry(symbol.clone()).or_insert_with(|| {
-            let chart = Chart::new(symbol.value().to_string(), ChartType::Candlestick, 1000);
-            ecs_world().lock().unwrap().spawn_chart(chart.clone());
-            create_rw_signal(chart)
-        });
-    });
-    charts.with(|map| map.get(symbol).copied().unwrap())
+
+pub fn get_chart_signal(symbol: &Symbol) -> Option<RwSignal<Chart>> {
+    let world = ecs_world().lock().unwrap();
+    world
+        .world
+        .query::<&ChartComponent>()
+        .iter()
+        .find(|(_, c)| c.0.with(|ch| ch.id == symbol.value()))
+        .map(|(_, c)| c.0)
 }
 
-pub fn global_charts() -> RwSignal<HashMap<Symbol, RwSignal<Chart>>> {
-    globals().charts
+pub fn ensure_chart(symbol: &Symbol) -> RwSignal<Chart> {
+    if let Some(sig) = get_chart_signal(symbol) {
+        return sig;
+    }
+    let mut world = ecs_world().lock().unwrap();
+    let chart = Chart::new(symbol.value().to_string(), ChartType::Candlestick, 1000);
+    let entity = world.spawn_chart(chart);
+    world.world.get::<&ChartComponent>(entity).map(|c| c.0).expect("chart just spawned")
 }
 
 pub fn stream_abort_handles() -> RwSignal<HashMap<Symbol, AbortHandle>> {
@@ -95,7 +98,6 @@ pub fn push_realtime_candle(candle: Candle) {
         world.world.spawn((CandleComponent(candle),));
         world.run_candle_system();
     }
-    sync_charts_from_ecs();
 }
 
 /// Replace or spawn a chart entity in the ECS world.
@@ -105,38 +107,14 @@ pub fn set_chart_in_ecs(symbol: &Symbol, chart: Chart) {
         let mut world = ecs_world().lock().unwrap();
         let mut found = false;
         for (_, comp) in world.world.query::<&mut ChartComponent>().iter() {
-            if comp.0.id == symbol.value() {
-                comp.0 = chart.clone();
+            if comp.0.with(|c| c.id.clone()) == symbol.value() {
+                comp.0.set(chart.clone());
                 found = true;
                 break;
             }
         }
         if !found {
-            world.world.spawn((ChartComponent(chart),));
+            world.spawn_chart(chart);
         }
     }
-    sync_charts_from_ecs();
-}
-
-/// Synchronize chart signals from the ECS world.
-pub fn sync_charts_from_ecs() {
-    use crate::domain::market_data::Symbol;
-    use crate::ecs::components::ChartComponent;
-
-    let world = ecs_world().lock().unwrap();
-    let updates: Vec<(Symbol, Chart)> = world
-        .world
-        .query::<&ChartComponent>()
-        .iter()
-        .map(|(_, comp)| (Symbol::from(comp.0.id.as_str()), comp.0.clone()))
-        .collect();
-    drop(world);
-
-    globals().charts.update(|map| {
-        for (symbol, chart) in updates {
-            if let Some(signal) = map.get(&symbol) {
-                signal.set(chart);
-            }
-        }
-    });
 }

--- a/tests/ecs_chart_update.rs
+++ b/tests/ecs_chart_update.rs
@@ -1,3 +1,4 @@
+use leptos::*;
 use price_chart_wasm::domain::chart::{Chart, value_objects::ChartType};
 use price_chart_wasm::domain::market_data::{Candle, OHLCV, Price, Symbol, Timestamp, Volume};
 use price_chart_wasm::ecs::components::ChartComponent;
@@ -13,7 +14,7 @@ fn set_chart_spawns_when_missing() {
     let mut query = world_ref.world.query::<&ChartComponent>();
     assert_eq!(query.iter().count(), 1);
     let stored = query.iter().next().unwrap().1;
-    assert_eq!(stored.0.id, chart.id);
+    assert_eq!(stored.0.with(|c| c.id.clone()), chart.id);
 }
 
 #[test]
@@ -37,5 +38,5 @@ fn set_chart_replaces_existing() {
     let world_ref = ecs_world().lock().unwrap();
     let mut query = world_ref.world.query::<&ChartComponent>();
     let stored = query.iter().next().unwrap().1;
-    assert_eq!(stored.0.get_candle_count(), 1);
+    assert_eq!(stored.0.with(|c| c.get_candle_count()), 1);
 }

--- a/tests/ecs_global_integration.rs
+++ b/tests/ecs_global_integration.rs
@@ -1,3 +1,4 @@
+use leptos::*;
 use price_chart_wasm::domain::market_data::{Candle, OHLCV, Price, Symbol, Timestamp, Volume};
 use price_chart_wasm::ecs::components::ChartComponent;
 use price_chart_wasm::global_state::{ecs_world, ensure_chart, push_realtime_candle};
@@ -9,7 +10,7 @@ fn ensure_chart_spawns_entity() {
     ensure_chart(&symbol);
     let world_ref = ecs_world().lock().unwrap();
     let mut query = world_ref.world.query::<&ChartComponent>();
-    let count = query.iter().filter(|(_, c)| c.0.id == symbol.value()).count();
+    let count = query.iter().filter(|(_, c)| c.0.with(|ch| ch.id == symbol.value())).count();
     assert_eq!(count, 1);
 }
 
@@ -32,5 +33,5 @@ fn push_candle_updates_world() {
     let world_ref = ecs_world().lock().unwrap();
     let mut query = world_ref.world.query::<&ChartComponent>();
     let chart_comp = query.iter().next().expect("chart component").1;
-    assert_eq!(chart_comp.0.get_candle_count(), 1);
+    assert_eq!(chart_comp.0.with(|c| c.get_candle_count()), 1);
 }

--- a/tests/ecs_signal_sync.rs
+++ b/tests/ecs_signal_sync.rs
@@ -1,13 +1,11 @@
 use leptos::*;
 use price_chart_wasm::domain::market_data::{Candle, OHLCV, Price, Symbol, Timestamp, Volume};
 use price_chart_wasm::global_state::{
-    ecs_world, ensure_chart, global_charts, push_realtime_candle, set_chart_in_ecs,
+    ecs_world, ensure_chart, push_realtime_candle, set_chart_in_ecs,
 };
-use std::collections::HashMap;
 
 #[test]
 fn push_candle_syncs_signal() {
-    global_charts().set(HashMap::new());
     ecs_world().lock().unwrap().world = hecs::World::new();
     let symbol = Symbol::from("SYNC");
     let chart = ensure_chart(&symbol);
@@ -27,7 +25,6 @@ fn push_candle_syncs_signal() {
 
 #[test]
 fn set_chart_updates_signal() {
-    global_charts().set(HashMap::new());
     ecs_world().lock().unwrap().world = hecs::World::new();
     let symbol = Symbol::from("SYNC2");
     let chart_signal = ensure_chart(&symbol);

--- a/tests/ecs_world.rs
+++ b/tests/ecs_world.rs
@@ -1,3 +1,4 @@
+use leptos::*;
 use price_chart_wasm::domain::chart::{Chart, value_objects::ChartType};
 use price_chart_wasm::domain::market_data::{Candle, OHLCV, Price, Timestamp, Volume};
 use price_chart_wasm::ecs::EcsWorld;
@@ -16,7 +17,7 @@ fn spawn_chart_entity() {
     let chart = Chart::new("test".into(), ChartType::Candlestick, 100);
     let entity = world.spawn_chart(chart.clone());
     let stored = world.world.get::<&ChartComponent>(entity).expect("chart component exists");
-    assert_eq!(stored.0.id, chart.id);
+    assert_eq!(stored.0.with(|c| c.id.clone()), chart.id);
 }
 
 #[test]
@@ -41,6 +42,6 @@ fn candle_system_applies_candles() {
 
     let mut query = world.world.query::<&ChartComponent>();
     let chart_comp = query.iter().next().expect("chart component").1;
-    assert_eq!(chart_comp.0.get_candle_count(), 1);
+    assert_eq!(chart_comp.0.with(|c| c.get_candle_count()), 1);
     assert_eq!(world.world.len(), 1);
 }

--- a/tests/multi_symbol.rs
+++ b/tests/multi_symbol.rs
@@ -1,11 +1,9 @@
 use leptos::*;
 use price_chart_wasm::domain::market_data::{Candle, OHLCV, Price, Symbol, Timestamp, Volume};
-use price_chart_wasm::global_state::{ensure_chart, global_charts};
-use std::collections::HashMap;
+use price_chart_wasm::global_state::ensure_chart;
 
 #[test]
 fn charts_accumulate_independently() {
-    global_charts().set(HashMap::new());
     let btc = Symbol::from("BTCUSDT");
     let eth = Symbol::from("ETHUSDT");
     let btc_chart = ensure_chart(&btc);


### PR DESCRIPTION
## Summary
- drop global `charts` map and related functions
- query ECS world for chart signals
- adapt systems to update chart signals
- refactor app to fetch charts via ECS
- adjust unit tests

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_6871193ea85483328fda18293236a5bc