### PR TITLE
docs: add cargo test step

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,6 @@
   - `cargo test`
 - If your changes touch only Markdown files, you can skip the build checks above.
 - Do not mention these commands in commit messages.
-- Запускайте тесты командой `cargo test`.
 - One of the readiness criteria is the absence of formatting issues and linter warnings.
 - Do not suppress warnings about unused code via `#[allow(dead_code)]`. Remove dead code instead.
 - When adding new functionality you must write tests.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,9 +5,10 @@
   - `cargo fmt --all`
   - `cargo check --tests --benches`
   - `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`
+  - `cargo test`
 - If your changes touch only Markdown files, you can skip the build checks above.
 - Do not mention these commands in commit messages.
-- Running tests (e.g. `wasm-pack test`) won't work due to wasm; they will run in GitHub Actions.
+- Запускайте тесты командой `cargo test`.
 - One of the readiness criteria is the absence of formatting issues and linter warnings.
 - Do not suppress warnings about unused code via `#[allow(dead_code)]`. Remove dead code instead.
 - When adding new functionality you must write tests.


### PR DESCRIPTION
## Summary
- update AGENTS instructions with a test step

## Testing
- `cargo fmt --all` *(fails: rustfmt component missing)*
- `cargo check --tests --benches` *(fails: missing wasm target)*
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings` *(fails: clippy component missing)*
- `cargo test` *(fails: missing wasm target)*

------
https://chatgpt.com/codex/tasks/task_e_687122611e348332a7d284bb58b5f69a