### PR TITLE
Streamline CI logs and cache cargo bin

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,21 +21,22 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
+            ~/.cargo/bin
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
       - name: Install wasm-pack
-        run: cargo install wasm-pack --version 0.13.1
+        run: cargo install wasm-pack --version 0.13.1 --quiet
       - name: Install wasm-tools
-        run: cargo install wasm-tools
+        run: cargo install wasm-tools --quiet
       - name: Update dependencies
-        run: cargo update
+        run: cargo update --quiet
       - name: Cargo check
-        run: cargo check --all-targets
+        run: cargo check --all-targets --quiet
       - name: Cargo clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings || echo 'Clippy warnings found'
+        run: cargo clippy --all-targets --all-features --quiet -- -D warnings || echo 'Clippy warnings found'
       - name: Run browser tests
-        run: wasm-pack test --headless --chrome
+        run: wasm-pack test -q --headless --chrome
       - name: Run Node.js tests
-        run: wasm-pack test --node
+        run: wasm-pack test -q --node

--- a/tests/ecs_full_pipeline.rs
+++ b/tests/ecs_full_pipeline.rs
@@ -1,18 +1,14 @@
 use leptos::*;
 use price_chart_wasm::domain::market_data::{Symbol, TimeInterval};
-use price_chart_wasm::global_state::{
-    ecs_world, ensure_chart, global_charts, push_realtime_candle,
-};
+use price_chart_wasm::global_state::{ecs_world, ensure_chart, push_realtime_candle};
 use price_chart_wasm::infrastructure::rendering::renderer::dummy_renderer;
 use price_chart_wasm::infrastructure::websocket::binance_client::BinanceWebSocketClient;
-use std::collections::HashMap;
 use wasm_bindgen_test::*;
 
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 #[wasm_bindgen_test]
 fn websocket_to_webgpu_pipeline() {
-    global_charts().set(HashMap::new());
     ecs_world().lock().unwrap().world = hecs::World::new();
 
     let symbol = Symbol::from("PIPE");


### PR DESCRIPTION
## Summary
- shrink GitHub Actions output with `--quiet`
- cache `~/.cargo/bin` between runs
- fix failing `ecs_full_pipeline` test

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`

------
https://chatgpt.com/codex/tasks/task_e_687124ce34b083328a4a22cfff00c840