### PR TITLE
Sync viewport component

### DIFF
--- a/src/ecs/mod.rs
+++ b/src/ecs/mod.rs
@@ -18,15 +18,21 @@ impl EcsWorld {
 
     /// Spawn a new chart entity with its component.
     pub fn spawn_chart(&mut self, chart: crate::domain::chart::Chart) -> hecs::Entity {
-        use crate::ecs::components::ChartComponent;
+        use crate::ecs::components::{ChartComponent, ViewportComponent};
         use leptos::create_rw_signal;
 
-        let signal = create_rw_signal(chart);
-        self.world.spawn((ChartComponent(signal),))
+        let signal = create_rw_signal(chart.clone());
+        let viewport = chart.viewport.clone();
+        self.world.spawn((ChartComponent(signal), ViewportComponent(viewport)))
     }
 
     /// Apply all pending candle components to charts.
     pub fn run_candle_system(&mut self) {
         crate::ecs::systems::apply_candles(&mut self.world);
+    }
+
+    /// Update all viewport components from their charts.
+    pub fn run_viewport_system(&mut self) {
+        crate::ecs::systems::sync_viewports(&mut self.world);
     }
 }

--- a/src/ecs/systems.rs
+++ b/src/ecs/systems.rs
@@ -1,7 +1,7 @@
 use hecs::World;
 
-use super::components::{CandleComponent, ChartComponent};
-use leptos::SignalUpdate;
+use super::components::{CandleComponent, ChartComponent, ViewportComponent};
+use leptos::{SignalUpdate, SignalWithUntracked};
 
 /// Apply new candles to all charts and remove processed candle entities.
 pub fn apply_candles(world: &mut World) {
@@ -22,5 +22,14 @@ pub fn apply_candles(world: &mut World) {
     candle_entities.extend(candles.into_iter().map(|(e, _)| e));
     for e in candle_entities {
         let _ = world.despawn(e);
+    }
+}
+
+/// Sync ViewportComponent with the Chart's internal viewport.
+pub fn sync_viewports(world: &mut World) {
+    for (_, (chart, viewport)) in world.query::<(&ChartComponent, &mut ViewportComponent)>().iter()
+    {
+        let vp = chart.0.with_untracked(|c| c.viewport.clone());
+        viewport.0 = vp;
     }
 }

--- a/src/global_state.rs
+++ b/src/global_state.rs
@@ -96,6 +96,7 @@ pub fn push_realtime_candle(candle: Candle) {
         let mut world = ecs_world().lock().unwrap();
         world.world.spawn((CandleComponent(candle),));
         world.run_candle_system();
+        world.run_viewport_system();
     }
 }
 
@@ -115,5 +116,6 @@ pub fn set_chart_in_ecs(symbol: &Symbol, chart: Chart) {
         if !found {
             world.spawn_chart(chart);
         }
+        world.run_viewport_system();
     }
 }

--- a/tests/viewport_component.rs
+++ b/tests/viewport_component.rs
@@ -1,0 +1,33 @@
+use leptos::SignalUpdate;
+use price_chart_wasm::domain::chart::{Chart, value_objects::ChartType};
+use price_chart_wasm::ecs::{
+    EcsWorld,
+    components::{ChartComponent, ViewportComponent},
+};
+
+#[test]
+fn spawn_chart_has_viewport_component() {
+    let mut world = EcsWorld::new();
+    let chart = Chart::new("test".into(), ChartType::Candlestick, 100);
+    let entity = world.spawn_chart(chart.clone());
+
+    let vp = world.world.get::<&ViewportComponent>(entity).expect("viewport component exists");
+    assert_eq!(vp.0, chart.viewport);
+}
+
+#[test]
+fn viewport_updates_after_zoom() {
+    let mut world = EcsWorld::new();
+    let chart = Chart::new("test".into(), ChartType::Candlestick, 100);
+    let entity = world.spawn_chart(chart);
+
+    {
+        let chart_comp = world.world.get::<&mut ChartComponent>(entity).unwrap();
+        chart_comp.0.update(|c| c.zoom(2.0, 0.5));
+    }
+
+    world.run_viewport_system();
+
+    let vp = world.world.get::<&ViewportComponent>(entity).unwrap();
+    assert!((vp.0.end_time - vp.0.start_time - 50.0).abs() < 1e-6);
+}


### PR DESCRIPTION
## Summary
- spawn `ViewportComponent` with `ChartComponent`
- sync viewport data via new ECS system
- call the sync system from global functions
- add tests for viewport component creation and updates

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`
- `cargo test` *(fails: could not execute wasm binary)*

------
https://chatgpt.com/codex/tasks/task_e_687139ce09d8833287a56c1d2d5c2aca