### PR TITLE
Use Node-based wasm tests in CI

### DIFF
--- a/.github/workflows/PIPELINES.md
+++ b/.github/workflows/PIPELINES.md
@@ -20,7 +20,7 @@
 The benchmark is run with:
 
 ```bash
-wasm-pack test --headless --chrome
+wasm-pack test --node
 ```
 
 Workflow `perf.yml` stores the `perf-log` file.

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Run benchmarks
         run: |
           set -o pipefail
-          wasm-pack test --headless --chrome | tee perf.log
+          wasm-pack test --node | tee perf.log
           python scripts/parse_perf_log.py perf.log benchmark_result.json
       - name: Analyze FPS
         run: |

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Run benchmarks
         run: |
           set -o pipefail
-          wasm-pack test --headless --chrome | tee perf.log
+          wasm-pack test --node | tee perf.log
       - name: Upload results
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,5 @@ jobs:
         run: cargo check --all-targets --quiet
       - name: Cargo clippy
         run: cargo clippy --all-targets --all-features --quiet -- -D warnings || echo 'Clippy warnings found'
-      - name: Run browser tests
-        run: wasm-pack test -q --headless --chrome
-      - name: Run Node.js tests
+      - name: Run tests
         run: wasm-pack test -q --node

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ The chart is composed of several layers:
 To measure performance use:
 
 ```bash
-wasm-pack test --headless --chrome
+wasm-pack test --node
 ```
 
 FPS is printed to the console and the `perf.yml` workflow saves the log as an

--- a/tests/README.md
+++ b/tests/README.md
@@ -63,9 +63,6 @@ wasm-pack test --node
 
 # Specific test
 wasm-pack test --node --test offset
-
-# In a browser (for integration tests)
-wasm-pack test --chrome --headless
 ```
 
 ## Key Checks


### PR DESCRIPTION
## Summary
- remove headless Chrome test steps
- update perf and benchmark pipelines to use Node
- document new test command in docs

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`
- `cargo test` *(fails: Exec format error)*
- `cargo test --no-run`

------
https://chatgpt.com/codex/tasks/task_e_6873eadb1e208332b7a1192aa9e27641