### PR TITLE
Update perf tests to use WasmPack on Node

### DIFF
--- a/.github/workflows/PIPELINES.md
+++ b/.github/workflows/PIPELINES.md
@@ -20,7 +20,7 @@
 The benchmark is run with:
 
 ```bash
-wasm-pack test --headless --chrome
+wasm-pack test --node
 ```
 
 Workflow `perf.yml` stores the `perf-log` file.

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Run benchmarks
         run: |
           set -o pipefail
-          wasm-pack test --headless --chrome | tee perf.log
+          wasm-pack test --node | tee perf.log
           python scripts/parse_perf_log.py perf.log benchmark_result.json
       - name: Analyze FPS
         run: |

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Run benchmarks
         run: |
           set -o pipefail
-          wasm-pack test --headless --chrome | tee perf.log
+          wasm-pack test --node | tee perf.log
       - name: Upload results
         uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ The chart is composed of several layers:
 To measure performance use:
 
 ```bash
-wasm-pack test --headless --chrome
+wasm-pack test --node
 ```
 
 FPS is printed to the console and the `perf.yml` workflow saves the log as an

--- a/tests/README.md
+++ b/tests/README.md
@@ -64,8 +64,8 @@ wasm-pack test --node
 # Specific test
 wasm-pack test --node --test offset
 
-# In a browser (for integration tests)
-wasm-pack test --chrome --headless
+# Node environment without a browser
+wasm-pack test --node
 ```
 
 ## Key Checks


### PR DESCRIPTION
## Summary
- run performance tests with `wasm-pack test --node`
- document Node-based testing in pipelines and READMEs

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`
- `cargo test`
- `wasm-pack test --node`

------
https://chatgpt.com/codex/tasks/task_e_6874fad542bc833295f5cd4cf8936b56