### PR TITLE
Enable Node tests

### DIFF
--- a/benches/webgpu_bench.rs
+++ b/benches/webgpu_bench.rs
@@ -6,8 +6,6 @@ use price_chart_wasm::infrastructure::rendering::renderer::WebGpuRenderer;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_test::*;
 
-wasm_bindgen_test_configure!(run_in_browser);
-
 fn setup_canvas(id: &str, width: u32, height: u32) {
     let window = web_sys::window().unwrap();
     let document = window.document().unwrap();

--- a/src/app.rs
+++ b/src/app.rs
@@ -1396,8 +1396,6 @@ mod tests {
     use wasm_bindgen::JsCast;
     use wasm_bindgen_test::*;
 
-    wasm_bindgen_test_configure!(run_in_browser);
-
     fn setup_container() -> web_sys::HtmlElement {
         let window = web_sys::window().unwrap();
         let document = window.document().unwrap();

--- a/tests/abort_handle.rs
+++ b/tests/abort_handle.rs
@@ -5,7 +5,6 @@ use price_chart_wasm::app::{current_symbol, stream_abort_handles};
 use price_chart_wasm::domain::market_data::Symbol;
 use std::time::Duration;
 use wasm_bindgen_test::*;
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 #[wasm_bindgen_test(async)]
 async fn aborts_previous_stream() {

--- a/tests/aggregator.rs
+++ b/tests/aggregator.rs
@@ -3,7 +3,6 @@ use price_chart_wasm::domain::market_data::{
     Candle, OHLCV, Price, TimeInterval, Timestamp, Volume,
 };
 use wasm_bindgen_test::*;
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 fn minute_candle(timestamp: u64, open: f64) -> Candle {
     Candle::new(

--- a/tests/axis_pan.rs
+++ b/tests/axis_pan.rs
@@ -1,7 +1,6 @@
 use price_chart_wasm::app::price_levels;
 use price_chart_wasm::domain::chart::value_objects::Viewport;
 use wasm_bindgen_test::*;
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 #[wasm_bindgen_test]
 fn price_levels_change_after_pan() {

--- a/tests/axis_zoom.rs
+++ b/tests/axis_zoom.rs
@@ -2,7 +2,6 @@ use price_chart_wasm::app::{price_levels, visible_range, visible_range_by_time};
 use price_chart_wasm::domain::chart::value_objects::Viewport;
 use price_chart_wasm::domain::market_data::{Candle, OHLCV, Price, Timestamp, Volume};
 use wasm_bindgen_test::*;
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 fn make_candle(i: u64) -> Candle {
     Candle::new(

--- a/tests/candle_alignment.rs
+++ b/tests/candle_alignment.rs
@@ -2,7 +2,6 @@ use price_chart_wasm::infrastructure::rendering::renderer::{
     EDGE_GAP, MAX_ELEMENT_WIDTH, MIN_ELEMENT_WIDTH, candle_x_position, spacing_ratio_for,
 };
 use wasm_bindgen_test::*;
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 #[wasm_bindgen_test]
 fn right_edge_alignment_basic() {

--- a/tests/candle_width_max_zoom.rs
+++ b/tests/candle_width_max_zoom.rs
@@ -1,6 +1,5 @@
 use price_chart_wasm::infrastructure::rendering::renderer::{MIN_ELEMENT_WIDTH, SPACING_RATIO};
 use wasm_bindgen_test::*;
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 #[wasm_bindgen_test]
 fn candle_width_at_max_zoom() {

--- a/tests/chart_pan.rs
+++ b/tests/chart_pan.rs
@@ -2,7 +2,6 @@ use price_chart_wasm::domain::chart::Chart;
 use price_chart_wasm::domain::chart::value_objects::ChartType;
 use price_chart_wasm::domain::chart::value_objects::Viewport;
 use wasm_bindgen_test::*;
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 #[wasm_bindgen_test]
 fn horizontal_pan_moves_viewport() {

--- a/tests/chart_positioning.rs
+++ b/tests/chart_positioning.rs
@@ -2,7 +2,6 @@ use price_chart_wasm::infrastructure::rendering::renderer::{
     EDGE_GAP, MAX_ELEMENT_WIDTH, MIN_ELEMENT_WIDTH, candle_x_position, spacing_ratio_for,
 };
 use wasm_bindgen_test::*;
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 #[wasm_bindgen_test]
 fn chart_positioning_edge_cases() {

--- a/tests/dynamic_spacing.rs
+++ b/tests/dynamic_spacing.rs
@@ -1,6 +1,5 @@
 use price_chart_wasm::infrastructure::rendering::renderer::spacing_ratio_for;
 use wasm_bindgen_test::*;
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 #[wasm_bindgen_test]
 fn spacing_decreases_on_zoom_in() {

--- a/tests/ecs_full_pipeline.rs
+++ b/tests/ecs_full_pipeline.rs
@@ -5,8 +5,6 @@ use price_chart_wasm::infrastructure::rendering::renderer::dummy_renderer;
 use price_chart_wasm::infrastructure::websocket::binance_client::BinanceWebSocketClient;
 use wasm_bindgen_test::*;
 
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
-
 #[wasm_bindgen_test]
 fn websocket_to_webgpu_pipeline() {
     ecs_world().lock().unwrap().world = hecs::World::new();

--- a/tests/geometry.rs
+++ b/tests/geometry.rs
@@ -2,7 +2,6 @@ use insta::{assert_json_snapshot, with_settings};
 use price_chart_wasm::domain::market_data::{Candle, OHLCV, Price, Timestamp, Volume};
 use price_chart_wasm::infrastructure::rendering::gpu_structures::CandleGeometry;
 use wasm_bindgen_test::*;
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 fn sample_candles() -> Vec<Candle> {
     vec![

--- a/tests/gpu_memory.rs
+++ b/tests/gpu_memory.rs
@@ -1,7 +1,6 @@
 use price_chart_wasm::infrastructure::rendering::renderer::WebGpuRenderer;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_test::*;
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 fn setup_canvas(id: &str) {
     let window = web_sys::window().unwrap();

--- a/tests/grid_vertices.rs
+++ b/tests/grid_vertices.rs
@@ -1,6 +1,5 @@
 use price_chart_wasm::infrastructure::rendering::gpu_structures::CandleGeometry;
 use wasm_bindgen_test::*;
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 #[wasm_bindgen_test]
 fn grid_vertex_count_and_bounds() {

--- a/tests/indicator_vertices.rs
+++ b/tests/indicator_vertices.rs
@@ -2,7 +2,6 @@ use price_chart_wasm::domain::market_data::services::MarketAnalysisService;
 use price_chart_wasm::domain::market_data::{Candle, OHLCV, Price, Timestamp, Volume};
 use price_chart_wasm::infrastructure::rendering::gpu_structures::{CandleGeometry, IndicatorType};
 use wasm_bindgen_test::*;
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 #[wasm_bindgen_test]
 fn current_price_line_vertices() {

--- a/tests/market_data.rs
+++ b/tests/market_data.rs
@@ -2,7 +2,6 @@ use price_chart_wasm::domain::market_data::{
     Candle, CandleSeries, OHLCV, Price, Timestamp, Volume,
 };
 use wasm_bindgen_test::*;
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 #[wasm_bindgen_test]
 fn candle_methods() {

--- a/tests/moving_average.rs
+++ b/tests/moving_average.rs
@@ -2,7 +2,6 @@ use price_chart_wasm::domain::market_data::{
     Candle, OHLCV, Price, Timestamp, Volume, services::MarketAnalysisService,
 };
 use wasm_bindgen_test::*;
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 fn create_candle(close: f64, index: u64) -> Candle {
     Candle::new(

--- a/tests/msaa.rs
+++ b/tests/msaa.rs
@@ -1,6 +1,5 @@
 use price_chart_wasm::infrastructure::rendering::renderer::MSAA_SAMPLE_COUNT;
 use wasm_bindgen_test::*;
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 #[wasm_bindgen_test]
 fn msaa_sample_count_is_four() {

--- a/tests/offset.rs
+++ b/tests/offset.rs
@@ -2,7 +2,6 @@ use price_chart_wasm::infrastructure::rendering::renderer::{
     EDGE_GAP, MAX_ELEMENT_WIDTH, MIN_ELEMENT_WIDTH, candle_x_position, spacing_ratio_for,
 };
 use wasm_bindgen_test::*;
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 #[wasm_bindgen_test]
 fn candle_offset_calculation() {

--- a/tests/pan_viewport.rs
+++ b/tests/pan_viewport.rs
@@ -2,7 +2,6 @@ use price_chart_wasm::app::visible_range_by_time;
 use price_chart_wasm::domain::chart::value_objects::Viewport;
 use price_chart_wasm::domain::market_data::{Candle, OHLCV, Price, Timestamp, Volume};
 use wasm_bindgen_test::*;
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 fn make_candle(i: u64) -> Candle {
     Candle::new(

--- a/tests/performance_limit.rs
+++ b/tests/performance_limit.rs
@@ -5,7 +5,6 @@ use price_chart_wasm::domain::{
 use price_chart_wasm::infrastructure::rendering::renderer::WebGpuRenderer;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_test::*;
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 fn setup_canvas(id: &str, width: u32, height: u32) {
     let window = web_sys::window().unwrap();

--- a/tests/positioning_regression.rs
+++ b/tests/positioning_regression.rs
@@ -2,7 +2,6 @@ use price_chart_wasm::infrastructure::rendering::renderer::{
     EDGE_GAP, MAX_ELEMENT_WIDTH, MIN_ELEMENT_WIDTH, candle_x_position, spacing_ratio_for,
 };
 use wasm_bindgen_test::*;
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 /// Regression test: ensure new logic didn't break basics
 #[wasm_bindgen_test]

--- a/tests/realtime_viewport.rs
+++ b/tests/realtime_viewport.rs
@@ -2,7 +2,6 @@ use price_chart_wasm::domain::chart::Chart;
 use price_chart_wasm::domain::chart::value_objects::{ChartType, Viewport};
 use price_chart_wasm::domain::market_data::{Candle, OHLCV, Price, Timestamp, Volume};
 use wasm_bindgen_test::*;
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 #[wasm_bindgen_test]
 fn add_realtime_candle_keeps_viewport() {

--- a/tests/reconnect.rs
+++ b/tests/reconnect.rs
@@ -6,7 +6,6 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use std::time::Duration;
 use wasm_bindgen_test::*;
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 #[wasm_bindgen_test(async)]
 async fn reconnect_called_on_failure() {

--- a/tests/rendering_sync.rs
+++ b/tests/rendering_sync.rs
@@ -4,7 +4,6 @@ use price_chart_wasm::domain::{
 };
 use price_chart_wasm::infrastructure::rendering::renderer::dummy_renderer;
 use wasm_bindgen_test::*;
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 fn sample_chart() -> Chart {
     let mut chart = Chart::new("sync".into(), ChartType::Candlestick, 10);

--- a/tests/series_expansion.rs
+++ b/tests/series_expansion.rs
@@ -2,7 +2,6 @@ use price_chart_wasm::app::visible_range;
 use price_chart_wasm::domain::chart::{Chart, value_objects::ChartType};
 use price_chart_wasm::domain::market_data::{Candle, OHLCV, Price, Timestamp, Volume};
 use wasm_bindgen_test::*;
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 fn make_candle(i: u64) -> Candle {
     Candle::new(

--- a/tests/single_candle_width.rs
+++ b/tests/single_candle_width.rs
@@ -2,7 +2,6 @@ use price_chart_wasm::infrastructure::rendering::renderer::{
     MAX_ELEMENT_WIDTH, MIN_ELEMENT_WIDTH, spacing_ratio_for,
 };
 use wasm_bindgen_test::*;
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 #[wasm_bindgen_test]
 fn single_candle_pixel_width() {

--- a/tests/start_realtime.rs
+++ b/tests/start_realtime.rs
@@ -4,7 +4,6 @@ use price_chart_wasm::domain::market_data::{
     Candle, OHLCV, Price, TimeInterval, Timestamp, Volume,
 };
 use wasm_bindgen_test::*;
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 fn test_candle(ts: u64) -> Candle {
     Candle::new(

--- a/tests/stream_abort_no_panic.rs
+++ b/tests/stream_abort_no_panic.rs
@@ -7,8 +7,6 @@ use price_chart_wasm::domain::market_data::Symbol;
 use std::time::Duration;
 use wasm_bindgen_test::*;
 
-wasm_bindgen_test_configure!(run_in_browser);
-
 #[wasm_bindgen_test(async)]
 async fn stream_creation_and_abort() {
     current_symbol().set(Symbol::from("BTCUSDT"));

--- a/tests/switch_symbol_abort.rs
+++ b/tests/switch_symbol_abort.rs
@@ -6,8 +6,6 @@ use price_chart_wasm::domain::market_data::Symbol;
 use std::time::Duration;
 use wasm_bindgen_test::*;
 
-wasm_bindgen_test_configure!(run_in_browser);
-
 #[wasm_bindgen_test(async)]
 async fn aborts_old_stream_on_symbol_change() {
     let (handle, reg) = AbortHandle::new_pair();

--- a/tests/symbol_list.rs
+++ b/tests/symbol_list.rs
@@ -1,6 +1,5 @@
 use price_chart_wasm::domain::market_data::value_objects::{Symbol, default_symbols};
 use wasm_bindgen_test::*;
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 #[wasm_bindgen_test]
 fn returns_three_symbols() {

--- a/tests/time_label_format.rs
+++ b/tests/time_label_format.rs
@@ -2,7 +2,6 @@ use js_sys::Date;
 use price_chart_wasm::time_utils::format_time_label;
 use wasm_bindgen::JsValue;
 use wasm_bindgen_test::*;
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 #[wasm_bindgen_test]
 fn format_time_label_utc() {

--- a/tests/time_scale_sync.rs
+++ b/tests/time_scale_sync.rs
@@ -5,7 +5,6 @@ use price_chart_wasm::domain::market_data::{
 };
 use price_chart_wasm::time_utils::format_time_label;
 use wasm_bindgen_test::*;
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 fn make_candle(i: u64) -> Candle {
     Candle::new(

--- a/tests/tooltip_positioning.rs
+++ b/tests/tooltip_positioning.rs
@@ -2,7 +2,6 @@ use price_chart_wasm::infrastructure::rendering::renderer::{
     EDGE_GAP, MAX_ELEMENT_WIDTH, MIN_ELEMENT_WIDTH, candle_x_position, spacing_ratio_for,
 };
 use wasm_bindgen_test::*;
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 #[wasm_bindgen_test]
 fn tooltip_reverse_positioning() {

--- a/tests/viewport.rs
+++ b/tests/viewport.rs
@@ -1,6 +1,5 @@
 use price_chart_wasm::domain::chart::value_objects::Viewport;
 use wasm_bindgen_test::*;
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 #[wasm_bindgen_test]
 fn zoom_changes_time_range() {

--- a/tests/viewport_clamp.rs
+++ b/tests/viewport_clamp.rs
@@ -1,7 +1,6 @@
 use price_chart_wasm::domain::chart::{Chart, value_objects::ChartType};
 use price_chart_wasm::domain::market_data::{Candle, OHLCV, Price, Timestamp, Volume};
 use wasm_bindgen_test::*;
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 fn make_candle(i: u64) -> Candle {
     Candle::new(

--- a/tests/visibility_refresh.rs
+++ b/tests/visibility_refresh.rs
@@ -4,7 +4,6 @@ use price_chart_wasm::domain::{
 };
 use price_chart_wasm::infrastructure::rendering::renderer::dummy_renderer;
 use wasm_bindgen_test::*;
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 fn sample_chart() -> Chart {
     let mut chart = Chart::new("vis".to_string(), ChartType::Candlestick, 100);

--- a/tests/visible_len_zero.rs
+++ b/tests/visible_len_zero.rs
@@ -1,6 +1,5 @@
 use price_chart_wasm::infrastructure::rendering::renderer::candle_x_position;
 use wasm_bindgen_test::*;
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 #[wasm_bindgen_test]
 #[should_panic]

--- a/tests/volume_candle_sync.rs
+++ b/tests/volume_candle_sync.rs
@@ -4,7 +4,6 @@ use price_chart_wasm::infrastructure::rendering::renderer::{
     spacing_ratio_for,
 };
 use wasm_bindgen_test::*;
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 fn create_test_candles(count: usize) -> Vec<Candle> {
     let mut candles = Vec::new();

--- a/tests/volume_vertices.rs
+++ b/tests/volume_vertices.rs
@@ -1,6 +1,5 @@
 use price_chart_wasm::infrastructure::rendering::gpu_structures::CandleGeometry;
 use wasm_bindgen_test::*;
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 #[wasm_bindgen_test]
 fn volume_vertex_basic() {

--- a/tests/vs_transform.rs
+++ b/tests/vs_transform.rs
@@ -1,6 +1,5 @@
 use price_chart_wasm::infrastructure::rendering::gpu_structures::{CandleInstance, CandleVertex};
 use wasm_bindgen_test::*;
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 fn apply_vs(v: &CandleVertex, inst: &CandleInstance) -> (f32, f32) {
     let x = inst.x + v.position_x * inst.width;

--- a/tests/websocket_parse.rs
+++ b/tests/websocket_parse.rs
@@ -1,7 +1,6 @@
 use price_chart_wasm::domain::market_data::{Symbol, TimeInterval};
 use price_chart_wasm::infrastructure::websocket::binance_client::BinanceWebSocketClient;
 use wasm_bindgen_test::*;
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 #[wasm_bindgen_test]
 fn parses_kline_message() {

--- a/tests/width_sync_test.rs
+++ b/tests/width_sync_test.rs
@@ -2,7 +2,6 @@ use price_chart_wasm::infrastructure::rendering::renderer::{
     EDGE_GAP, MIN_ELEMENT_WIDTH, candle_x_position, spacing_ratio_for,
 };
 use wasm_bindgen_test::*;
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 #[wasm_bindgen_test]
 fn width_calculation_sync() {

--- a/tests/zoom_centering.rs
+++ b/tests/zoom_centering.rs
@@ -1,6 +1,5 @@
 use price_chart_wasm::domain::chart::value_objects::Viewport;
 use wasm_bindgen_test::*;
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 #[wasm_bindgen_test]
 fn zoom_pan_moves_toward_center() {

--- a/tests/zoom_preservation.rs
+++ b/tests/zoom_preservation.rs
@@ -1,7 +1,6 @@
 use price_chart_wasm::domain::chart::{Chart, value_objects::ChartType};
 use price_chart_wasm::domain::market_data::{Candle, OHLCV, Price, Timestamp, Volume};
 use wasm_bindgen_test::*;
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 fn test_candle(ts: u64) -> Candle {
     Candle::new(

--- a/tests/zoom_price.rs
+++ b/tests/zoom_price.rs
@@ -1,6 +1,5 @@
 use price_chart_wasm::domain::chart::value_objects::Viewport;
 use wasm_bindgen_test::*;
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 #[wasm_bindgen_test]
 fn zoom_price_not_negative() {


### PR DESCRIPTION
## Summary
- drop `run_in_browser` from tests so they run in Node

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`
- `cargo test` *(fails: Exec format error)*
- `wasm-pack test --node` *(fails: panic in setup_container)*

------
https://chatgpt.com/codex/tasks/task_e_68753c182b3083328addf9eabff4cbc3