### PR TITLE
Switch tests to headless Chrome

### DIFF
--- a/.github/workflows/PIPELINES.md
+++ b/.github/workflows/PIPELINES.md
@@ -20,7 +20,7 @@
 The benchmark is run with:
 
 ```bash
-wasm-pack test --node
+wasm-pack test --chrome --headless
 ```
 
 Workflow `perf.yml` stores the `perf-log` file.

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Run benchmarks
         run: |
           set -o pipefail
-          wasm-pack test --node | tee perf.log
+          wasm-pack test --chrome --headless | tee perf.log
           python scripts/parse_perf_log.py perf.log benchmark_result.json
       - name: Analyze FPS
         run: |

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Run benchmarks
         run: |
           set -o pipefail
-          wasm-pack test --node | tee perf.log
+          wasm-pack test --chrome --headless | tee perf.log
       - name: Upload results
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,4 +39,4 @@ jobs:
       - name: Run Node.js tests
         env:
           INSTA_WORKSPACE_ROOT: ${{ github.workspace }}
-        run: wasm-pack test --node
+        run: wasm-pack test --chrome --headless

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ The chart is composed of several layers:
 To measure performance use:
 
 ```bash
-wasm-pack test --node
+wasm-pack test --chrome --headless
 ```
 
 FPS is printed to the console and the `perf.yml` workflow saves the log as an
@@ -144,7 +144,7 @@ The tests use [`wasm-bindgen-test`](https://docs.rs/wasm-bindgen-test). Run
 them with:
 
 ```bash
-wasm-pack test
+wasm-pack test --chrome --headless
 ```
 
 Alternatively install Node dependencies and run:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "webgpu-candles",
   "private": true,
   "scripts": {
-    "test": "wasm-pack test --node"
+    "test": "wasm-pack test --chrome --headless"
   },
   "devDependencies": {
     "wasm-pack": "^0.13.1"

--- a/tests/README.md
+++ b/tests/README.md
@@ -59,13 +59,13 @@ Before running the suite ensure the WebAssembly target is installed:
 The build script will fail if the target is missing.
 ```bash
 # All WASM tests
-wasm-pack test --node
+wasm-pack test --chrome --headless
 
 # Specific test
-wasm-pack test --node --test offset
+wasm-pack test --chrome --headless --test offset
 
-# Node environment without a browser
-wasm-pack test --node
+# Headless Chrome without UI
+wasm-pack test --chrome --headless
 ```
 
 ## Key Checks


### PR DESCRIPTION
## Summary
- run `wasm-pack` tests in headless Chrome
- update docs and workflows

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`
- `cargo test` *(fails: `Exec format error (os error 8)`)*

------
https://chatgpt.com/codex/tasks/task_e_6875a5abfc8883328f67c10a1ad838ec