### PR TITLE
Restrict CI to qqrm only

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  security-check:
+    runs-on: ubuntu-latest
+    outputs:
+      allowed: ${{ steps.verify.outputs.allowed }}
+    steps:
+      - id: verify
+        run: |
+          if [ "${{ github.event.pull_request.user.login }}" = "qqrm" ]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "allowed=false" >> "$GITHUB_OUTPUT"
+          fi
   test:
+    needs: security-check
+    if: needs.security-check.outputs.allowed == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/DOCS/PIPELINES.md
+++ b/DOCS/PIPELINES.md
@@ -7,3 +7,8 @@ This document outlines the CI pipelines used in this repository.
 - `benchmark.yml` — measures performance against baseline.
 - `perf.yml` — tracks WebAssembly size and rendering speed.
 - `release.yml` — publishes release builds and artifacts.
+
+## Security check
+
+Automated checks run only when a pull request is opened by `qqrm`.
+Pull requests from other users are ignored by CI.


### PR DESCRIPTION
## Summary
- drop trusted users list
- run checks only when PR author is `qqrm`
- update pipeline docs

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`
- `cargo test` *(fails: Exec format error for wasm binaries)*

------
https://chatgpt.com/codex/tasks/task_e_688b8920a18c8332875211523c4352f1