### PR TITLE
Enable seamless historical backfill

### DIFF
--- a/src/infrastructure/websocket/binance_client.rs
+++ b/src/infrastructure/websocket/binance_client.rs
@@ -331,6 +331,66 @@ impl BinanceWebSocketClient {
 
         Ok(candles)
     }
+
+    /// 📈 Load uiKlines up to the specified time
+    pub async fn fetch_historical_ui_klines_before(
+        &self,
+        end_time: u64,
+        limit: u32,
+    ) -> Result<Vec<Candle>, String> {
+        let symbol_upper = self.symbol.value().to_uppercase();
+        let interval_str = self.interval.to_binance_str();
+
+        let url = format!(
+            "https://api.binance.com/api/v3/uiKlines?symbol={symbol_upper}&interval={interval_str}&endTime={end_time}&limit={limit}"
+        );
+
+        get_logger().info(
+            LogComponent::Infrastructure("BinanceAPI"),
+            &format!("📈 Fetching {limit} uiKlines before {end_time} from: {url}"),
+        );
+
+        let response = Request::get(&url)
+            .send()
+            .await
+            .map_err(|e| format!("Failed to fetch historical data: {e:?}"))?;
+
+        if !response.ok() {
+            return Err(format!("HTTP error: {}", response.status()));
+        }
+
+        let klines: Vec<BinanceHistoricalKline> =
+            response.json().await.map_err(|e| format!("Failed to parse JSON: {e:?}"))?;
+
+        let mut candles = Vec::new();
+
+        for kline in klines {
+            let open = kline.1.parse::<f64>().map_err(|_| "Invalid open price")?;
+            let high = kline.2.parse::<f64>().map_err(|_| "Invalid high price")?;
+            let low = kline.3.parse::<f64>().map_err(|_| "Invalid low price")?;
+            let close = kline.4.parse::<f64>().map_err(|_| "Invalid close price")?;
+            let volume = kline.5.parse::<f64>().map_err(|_| "Invalid volume")?;
+
+            let ohlcv = OHLCV::new(
+                Price::new(open),
+                Price::new(high),
+                Price::new(low),
+                Price::new(close),
+                Volume::new(volume),
+            );
+
+            let candle = Candle::new(Timestamp::new(kline.0), ohlcv);
+
+            candles.push(candle);
+        }
+
+        get_logger().info(
+            LogComponent::Infrastructure("BinanceAPI"),
+            &format!("✅ Loaded {} uiKlines", candles.len()),
+        );
+
+        Ok(candles)
+    }
 }
 
 /// Simple helper to create a WebSocket connection

--- a/tests/history_backfill.rs
+++ b/tests/history_backfill.rs
@@ -1,0 +1,44 @@
+use price_chart_wasm::domain::{
+    chart::{Chart, value_objects::ChartType},
+    market_data::{Candle, OHLCV, Price, TimeInterval, Timestamp, Volume},
+};
+
+fn make_candle(ts: u64) -> Candle {
+    Candle::new(
+        Timestamp::new(ts),
+        OHLCV::new(
+            Price::new(1.0),
+            Price::new(1.0),
+            Price::new(1.0),
+            Price::new(1.0),
+            Volume::new(1.0),
+        ),
+    )
+}
+
+fn merge_batch(chart: &mut Chart, mut batch: Vec<Candle>) {
+    batch.sort_by_key(|c| c.timestamp.value());
+    batch.dedup_by_key(|c| c.timestamp.value());
+    for candle in batch {
+        chart.add_candle(candle);
+    }
+}
+
+#[test]
+fn backfill_three_batches() {
+    let mut chart = Chart::new("TST".to_string(), ChartType::Candlestick, 100);
+    for ts in 1000..=1002 {
+        chart.add_candle(make_candle(ts));
+    }
+
+    merge_batch(&mut chart, (997..=999).map(make_candle).collect());
+    merge_batch(&mut chart, (994..=996).map(make_candle).collect());
+    merge_batch(&mut chart, (991..=993).map(make_candle).collect());
+
+    let series = chart.get_series(TimeInterval::TwoSeconds).unwrap();
+    let candles = series.get_candles();
+    assert_eq!(candles.len(), 12);
+    for (i, c) in candles.iter().enumerate() {
+        assert_eq!(c.timestamp.value(), 991 + i as u64);
+    }
+}

--- a/tests/history_fetch.rs
+++ b/tests/history_fetch.rs
@@ -1,7 +1,7 @@
-use price_chart_wasm::app::should_fetch_history;
+use price_chart_wasm::app::{HISTORY_PRELOAD_THRESHOLD, should_fetch_history};
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 #[test]
 fn history_threshold_check() {
-    assert!(should_fetch_history(-60.0));
-    assert!(!should_fetch_history(-10.0));
+    assert!(should_fetch_history(HISTORY_PRELOAD_THRESHOLD - 1));
+    assert!(!should_fetch_history(HISTORY_PRELOAD_THRESHOLD + 1));
 }

--- a/tests/pan_offset.rs
+++ b/tests/pan_offset.rs
@@ -1,20 +1,7 @@
-use price_chart_wasm::app::{HISTORY_FETCH_THRESHOLD, PAN_SENSITIVITY_BASE, should_fetch_history};
+use price_chart_wasm::app::{HISTORY_PRELOAD_THRESHOLD, should_fetch_history};
 
 #[test]
-fn pan_direction_and_history_activation() {
-    let mut offset = 0.0;
-    let delta_x = 10.0;
-    let zoom_level = 1.0;
-    let pan_sensitivity = PAN_SENSITIVITY_BASE / zoom_level;
-
-    // Simulate dragging to the right
-    offset -= delta_x * pan_sensitivity;
-    assert!(offset < 0.0);
-    assert!(!should_fetch_history(offset));
-
-    // Drag far enough to cross the history threshold
-    let mut offset_big = 0.0;
-    let delta_x_big = (HISTORY_FETCH_THRESHOLD.abs() + 1.0) / pan_sensitivity;
-    offset_big -= delta_x_big * pan_sensitivity;
-    assert!(should_fetch_history(offset_big));
+fn start_index_triggers_history() {
+    assert!(should_fetch_history(HISTORY_PRELOAD_THRESHOLD - 5));
+    assert!(!should_fetch_history(HISTORY_PRELOAD_THRESHOLD + 5));
 }


### PR DESCRIPTION
## Summary
- trigger history fetch when left index crosses preload threshold
- backfill via uiKlines with deduplication and backoff
- cover backfill merging in tests

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`
- `cargo test` *(fails: Exec format error (os error 8))*

------
https://chatgpt.com/codex/tasks/task_e_68a820223da883329936523f58caa84d