### PR TITLE
Adjust GitHub Pages URLs for release and dev builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Clean dist
         run: rm -rf dist
       - name: Build
-        run: trunk build --release --dist dist --public-url /webgpu-candles/dev/
+        run: trunk build --release --dist dist --public-url /dev/
       - name: Save version
         run: echo ${{ github.sha }} > dist/version
       - name: Archive dist
@@ -49,8 +49,9 @@ jobs:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
         run: scripts/send_to_bot.sh dist.tar.gz "Development build"
-      - name: Copy dist to docs/dev
+      - name: Reset docs/dev and copy dist
         run: |
+          rm -rf docs/dev
           mkdir -p docs/dev
           cp -r dist/* docs/dev/
       - name: Commit dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Clean dist
         run: rm -rf dist
       - name: Build
-        run: trunk build --release --dist dist --public-url /webgpu-candles/
+        run: trunk build --release --dist dist --public-url /
       - name: Save version
         run: echo ${{ github.sha }} > dist/version
       - name: Archive dist

--- a/Trunk.toml
+++ b/Trunk.toml
@@ -1,4 +1,4 @@
 [build]
 filehash = false
 dist = "dist-local"
-public_url = "/webgpu-candles/"
+public_url = "/"

--- a/src/app.rs
+++ b/src/app.rs
@@ -15,8 +15,6 @@ use std::sync::Arc;
 use std::time::Duration;
 use wasm_bindgen::JsCast;
 
-use std::time::Duration;
-
 use crate::event_utils::{EventOptions, wheel_event_options, window_event_listener_with_options};
 use crate::global_signals;
 use crate::global_state::{


### PR DESCRIPTION
## Summary
- serve release build from root path
- serve dev build from `/dev/`

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`
- `cargo test` *(fails: Exec format error)*
- `cargo test --target x86_64-unknown-linux-gnu` *(fails: SurfaceTarget::Canvas not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a83067595c83328196b8bc161b2e2b