### PR TITLE
docs: clarify zoom and history requirements

### DIFF
--- a/DOCS/FEATURES.md
+++ b/DOCS/FEATURES.md
@@ -3,6 +3,8 @@
 The project targets a fully interactive trading chart with the following capabilities:
 
 - Candlestick chart with zoom and scroll.
+  - Mouse-wheel zoom recenters the candle under the cursor.
+  - Zooming loads older candles when the left edge nears history.
 - Time axis showing timeframe markers.
 - Price axis with dynamic levels and markers.
 - Cursor tooltip displaying OHLCV values on hover.


### PR DESCRIPTION
## Summary
- specify that mouse-wheel zoom recenters the candle under the cursor
- document that zooming may load older candles when nearing history

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68a852307dc88332b5e097e0260e5934