### PR TITLE
Fix viewport zoom anchoring to cursor

### DIFF
--- a/src/domain/chart/value_objects.rs
+++ b/src/domain/chart/value_objects.rs
@@ -67,10 +67,10 @@ impl Viewport {
     pub fn zoom(&mut self, factor: f32, center_x: f32) {
         let current_range = self.time_range();
         let new_range = current_range / factor as f64;
-        let center_time = self.start_time + current_range * center_x as f64;
+        let anchor_time = self.start_time + current_range * center_x as f64;
 
-        self.start_time = center_time - new_range / 2.0;
-        self.end_time = center_time + new_range / 2.0;
+        self.start_time = anchor_time - new_range * center_x as f64;
+        self.end_time = self.start_time + new_range;
     }
 
     /// Scale prices vertically

--- a/tests/viewport.rs
+++ b/tests/viewport.rs
@@ -17,6 +17,21 @@ fn zoom_changes_time_range() {
 }
 
 #[wasm_bindgen_test]
+fn zoom_preserves_cursor_anchor() {
+    let mut vp = Viewport {
+        start_time: 0.0,
+        end_time: 100.0,
+        min_price: 0.0,
+        max_price: 100.0,
+        width: 800,
+        height: 600,
+    };
+    vp.zoom(2.0, 0.8);
+    assert!((vp.start_time - 40.0).abs() < 1e-6);
+    assert!((vp.end_time - 90.0).abs() < 1e-6);
+}
+
+#[wasm_bindgen_test]
 fn pan_moves_viewport() {
     let mut vp = Viewport {
         start_time: 0.0,

--- a/tests/zoom_centering.rs
+++ b/tests/zoom_centering.rs
@@ -15,6 +15,6 @@ fn zoom_pan_moves_toward_center() {
     vp.zoom(2.0, 0.25);
     vp.pan(-0.25, 0.0);
 
-    assert!((vp.start_time + 12.5).abs() < 1e-6);
-    assert!((vp.end_time - 37.5).abs() < 1e-6);
+    assert!((vp.start_time - 0.0).abs() < 1e-6);
+    assert!((vp.end_time - 50.0).abs() < 1e-6);
 }


### PR DESCRIPTION
## Summary
- anchor viewport zoom around the cursor position
- test that time anchor stays under cursor after zoom
- adjust pan test expectations for new behavior

## Testing
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`
- `cargo test` *(fails: Exec format error)*


------
https://chatgpt.com/codex/tasks/task_e_68a87a386c2483328c752aadbd00ef6a