### PR TITLE
Enable WebGPU flags for benchmark workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -37,6 +37,8 @@ jobs:
       - name: Install wasm-pack
         run: cargo install wasm-pack --version 0.13.1
       - name: Run benchmarks
+        env:
+          WASM_BINDGEN_TEST_BROWSER_ARGS: "--no-sandbox --enable-unsafe-webgpu"
         run: |
           set -o pipefail
           wasm-pack test --chrome --headless | tee perf.log


### PR DESCRIPTION
## Summary
- allow passing WebGPU flags to Chrome in benchmark workflow

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`
- `cargo test` *(fails: `SurfaceTarget::Canvas` not found)*
- `WASM_BINDGEN_TEST_BROWSER_ARGS="--no-sandbox --enable-unsafe-webgpu" wasm-pack test --chrome --headless` *(fails: `grid_vertices` test failure)*

------
https://chatgpt.com/codex/tasks/task_e_68a8896917088332ba0b64ec592ab9d2