### PR TITLE
Remove actor restriction from build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,6 @@ concurrency:
 
 jobs:
   build:
-    if: ${{ github.actor == 'qqrm' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- let build workflow run for all commit authors `F:.github/workflows/build.yml#L13-L15`

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`
- `cargo test` *(fails: Exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_68a8bbfd3b248332800d8c6ee1f0df0b