### PR TITLE
Add Node test job for logic-only tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,3 +53,34 @@ jobs:
         env:
           INSTA_WORKSPACE_ROOT: ${{ github.workspace }}
         run: wasm-pack test --chrome --headless
+
+  node-test:
+    if: ${{ github.actor == 'qqrm' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: nightly
+          targets: wasm32-unknown-unknown
+          components: rust-src
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Cache cargo
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ~/.cargo/bin
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+      - name: Install dependencies
+        run: npm ci
+      - name: Run logic-only tests
+        env:
+          INSTA_WORKSPACE_ROOT: ${{ github.workspace }}
+        run: npm run test:node -- --features logic-only --test logic_only

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ quickcheck_macros = "1"
 
 [features]
 parallel = ["rayon"]
+logic-only = []
 
 [profile.dev]
 panic = "unwind"  # Preserves stack traces

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "webgpu-candles",
   "private": true,
   "scripts": {
-    "test": "wasm-pack test --chrome --headless"
+    "test": "wasm-pack test --chrome --headless",
+    "test:node": "wasm-pack test --node"
   },
   "devDependencies": {
     "wasm-pack": "^0.13.1"

--- a/tests/logic_only.rs
+++ b/tests/logic_only.rs
@@ -1,0 +1,11 @@
+#![cfg(feature = "logic-only")]
+
+use price_chart_wasm::time_utils::format_time_label;
+use wasm_bindgen_test::*;
+
+#[wasm_bindgen_test]
+fn format_time_label_basic() {
+    assert_eq!(format_time_label(0, 2.0), "00:00");
+    assert_eq!(format_time_label(0, 1.5), "01.01");
+    assert_eq!(format_time_label(0, 0.5), "01.1970");
+}


### PR DESCRIPTION
## Summary
- add npm script to run wasm-pack tests under Node
- introduce logic-only feature with a simple wasm test
- run logic-only tests in separate workflow job

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty --no-deps -- -D warnings`
- `cargo test` *(fails: build did not complete)*
- `npm run test:node -- --features logic-only --test logic_only` *(fails: wasm-pack not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a93e03a1dc8332aac9e79bed0e5dec