### PR TITLE
feat: split tests into logic-only and render profiles

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,11 +53,11 @@ jobs:
         run: cargo check --all-targets --quiet
       - name: Cargo clippy
         run: cargo clippy --all-targets --all-features --quiet -- -D warnings || echo 'Clippy warnings found'
-      - name: Run Node.js tests
+      - name: Run render tests
         env:
           INSTA_WORKSPACE_ROOT: ${{ github.workspace }}
           CHROMIUM_FLAGS: --enable-unsafe-webgpu
-        run: wasm-pack test --chrome --headless
+        run: wasm-pack test --chrome --headless -- --features render
 
   node-test:
     if: ${{ github.actor == 'qqrm' }}
@@ -88,4 +88,4 @@ jobs:
       - name: Run logic-only tests
         env:
           INSTA_WORKSPACE_ROOT: ${{ github.workspace }}
-        run: npm run test:node -- --features logic-only --test logic_only
+        run: npm run test:node -- --features logic-only

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ quickcheck_macros = "1"
 [features]
 parallel = ["rayon"]
 logic-only = []
+render = []
 
 [profile.dev]
 panic = "unwind"  # Preserves stack traces

--- a/tests/README.md
+++ b/tests/README.md
@@ -58,14 +58,14 @@ Before running the suite ensure the WebAssembly target is installed:
 
 The build script will fail if the target is missing.
 ```bash
-# All WASM tests
-wasm-pack test --chrome --headless
+# Logic-only tests
+wasm-pack test --node -- --features logic-only
 
-# Specific test
-wasm-pack test --chrome --headless --test offset
+# Render tests
+wasm-pack test --chrome --headless -- --features render
 
-# Headless Chrome without UI
-wasm-pack test --chrome --headless
+# Specific render test
+wasm-pack test --chrome --headless -- --features render --test offset
 ```
 
 ## Key Checks

--- a/tests/abort_handle.rs
+++ b/tests/abort_handle.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use futures::future::{AbortHandle, Abortable};
 use gloo_timers::future::sleep;
 use leptos::*;

--- a/tests/aggregator.rs
+++ b/tests/aggregator.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use price_chart_wasm::domain::market_data::services::Aggregator;
 use price_chart_wasm::domain::market_data::{
     Candle, OHLCV, Price, TimeInterval, Timestamp, Volume,

--- a/tests/auto_scroll.rs
+++ b/tests/auto_scroll.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use price_chart_wasm::app::should_auto_scroll;
 
 #[test]

--- a/tests/axis_pan.rs
+++ b/tests/axis_pan.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use price_chart_wasm::app::price_levels;
 use price_chart_wasm::domain::chart::value_objects::Viewport;
 use wasm_bindgen_test::*;

--- a/tests/axis_zoom.rs
+++ b/tests/axis_zoom.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use price_chart_wasm::app::{price_levels, visible_range, visible_range_by_time};
 use price_chart_wasm::domain::chart::value_objects::Viewport;
 use price_chart_wasm::domain::market_data::{Candle, OHLCV, Price, Timestamp, Volume};

--- a/tests/candle_alignment.rs
+++ b/tests/candle_alignment.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use price_chart_wasm::infrastructure::rendering::renderer::{
     EDGE_GAP, MAX_ELEMENT_WIDTH, MIN_ELEMENT_WIDTH, candle_x_position, spacing_ratio_for,
 };

--- a/tests/candle_width_max_zoom.rs
+++ b/tests/candle_width_max_zoom.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use price_chart_wasm::infrastructure::rendering::renderer::{MIN_ELEMENT_WIDTH, SPACING_RATIO};
 use wasm_bindgen_test::*;
 

--- a/tests/chart_pan.rs
+++ b/tests/chart_pan.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use price_chart_wasm::domain::chart::Chart;
 use price_chart_wasm::domain::chart::value_objects::ChartType;
 use price_chart_wasm::domain::chart::value_objects::Viewport;

--- a/tests/chart_positioning.rs
+++ b/tests/chart_positioning.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use price_chart_wasm::infrastructure::rendering::renderer::{
     EDGE_GAP, MAX_ELEMENT_WIDTH, MIN_ELEMENT_WIDTH, candle_x_position, spacing_ratio_for,
 };

--- a/tests/current_time.rs
+++ b/tests/current_time.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use price_chart_wasm::app::visible_range;
 use price_chart_wasm::domain::chart::{Chart, value_objects::ChartType};
 use price_chart_wasm::domain::market_data::{Candle, OHLCV, Price, Timestamp, Volume};

--- a/tests/dynamic_spacing.rs
+++ b/tests/dynamic_spacing.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use price_chart_wasm::infrastructure::rendering::renderer::spacing_ratio_for;
 use wasm_bindgen_test::*;
 

--- a/tests/ecs_chart_update.rs
+++ b/tests/ecs_chart_update.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use leptos::*;
 use price_chart_wasm::domain::chart::{Chart, value_objects::ChartType};
 use price_chart_wasm::domain::market_data::{Candle, OHLCV, Price, Symbol, Timestamp, Volume};

--- a/tests/ecs_full_pipeline.rs
+++ b/tests/ecs_full_pipeline.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use leptos::*;
 use price_chart_wasm::domain::market_data::{Symbol, TimeInterval};
 use price_chart_wasm::global_state::{ecs_world, ensure_chart, push_realtime_candle};

--- a/tests/ecs_global_integration.rs
+++ b/tests/ecs_global_integration.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use leptos::*;
 use price_chart_wasm::domain::market_data::{Candle, OHLCV, Price, Symbol, Timestamp, Volume};
 use price_chart_wasm::ecs::components::ChartComponent;

--- a/tests/ecs_signal_sync.rs
+++ b/tests/ecs_signal_sync.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use leptos::*;
 use price_chart_wasm::domain::market_data::{Candle, OHLCV, Price, Symbol, Timestamp, Volume};
 use price_chart_wasm::global_state::{

--- a/tests/ecs_world.rs
+++ b/tests/ecs_world.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use leptos::*;
 use price_chart_wasm::domain::chart::{Chart, value_objects::ChartType};
 use price_chart_wasm::domain::market_data::{Candle, OHLCV, Price, Timestamp, Volume};

--- a/tests/geometry.rs
+++ b/tests/geometry.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use price_chart_wasm::domain::market_data::{Candle, OHLCV, Price, Timestamp, Volume};
 use price_chart_wasm::infrastructure::rendering::gpu_structures::CandleGeometry;
 use wasm_bindgen_test::*;

--- a/tests/gpu_memory.rs
+++ b/tests/gpu_memory.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use price_chart_wasm::infrastructure::rendering::renderer::WebGpuRenderer;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_test::*;

--- a/tests/grid_vertices.rs
+++ b/tests/grid_vertices.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use price_chart_wasm::infrastructure::rendering::gpu_structures::CandleGeometry;
 use wasm_bindgen_test::*;
 

--- a/tests/historical_ma_render.rs
+++ b/tests/historical_ma_render.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use price_chart_wasm::domain::chart::{Chart, value_objects::ChartType};
 use price_chart_wasm::domain::market_data::{Candle, OHLCV, Price, Timestamp, Volume};
 use price_chart_wasm::infrastructure::rendering::renderer::dummy_renderer;

--- a/tests/history_backfill.rs
+++ b/tests/history_backfill.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use price_chart_wasm::domain::{
     chart::{Chart, value_objects::ChartType},
     market_data::{Candle, OHLCV, Price, TimeInterval, Timestamp, Volume},

--- a/tests/history_fetch.rs
+++ b/tests/history_fetch.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use price_chart_wasm::app::{HISTORY_PRELOAD_THRESHOLD, should_fetch_history};
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 #[test]

--- a/tests/indicator_engine.rs
+++ b/tests/indicator_engine.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use price_chart_wasm::domain::market_data::{
     Candle, OHLCV, Price, Timestamp, Volume, indicator_engine::MovingAverageEngine,
     services::MarketAnalysisService,

--- a/tests/indicator_perf.rs
+++ b/tests/indicator_perf.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 #[cfg(not(target_arch = "wasm32"))]
 use price_chart_wasm::domain::market_data::{
     Candle, OHLCV, Price, Timestamp, Volume, indicator_engine::MovingAverageEngine,

--- a/tests/indicator_vertices.rs
+++ b/tests/indicator_vertices.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use price_chart_wasm::domain::market_data::services::MarketAnalysisService;
 use price_chart_wasm::domain::market_data::{Candle, OHLCV, Price, Timestamp, Volume};
 use price_chart_wasm::infrastructure::rendering::gpu_structures::{CandleGeometry, IndicatorType};

--- a/tests/interval_restart.rs
+++ b/tests/interval_restart.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use gloo_timers::future::sleep;
 use leptos::*;
 use price_chart_wasm::app::{

--- a/tests/market_data.rs
+++ b/tests/market_data.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use price_chart_wasm::domain::market_data::{
     Candle, CandleSeries, OHLCV, Price, Timestamp, Volume,
 };

--- a/tests/moving_average.rs
+++ b/tests/moving_average.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use price_chart_wasm::domain::market_data::{
     Candle, OHLCV, Price, Timestamp, Volume, services::MarketAnalysisService,
 };

--- a/tests/msaa.rs
+++ b/tests/msaa.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use price_chart_wasm::infrastructure::rendering::renderer::MSAA_SAMPLE_COUNT;
 use wasm_bindgen_test::*;
 

--- a/tests/multi_symbol.rs
+++ b/tests/multi_symbol.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use leptos::*;
 use price_chart_wasm::domain::market_data::{Candle, OHLCV, Price, Symbol, Timestamp, Volume};
 use price_chart_wasm::global_state::ensure_chart;

--- a/tests/offset.rs
+++ b/tests/offset.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use price_chart_wasm::infrastructure::rendering::renderer::{
     EDGE_GAP, MAX_ELEMENT_WIDTH, MIN_ELEMENT_WIDTH, candle_x_position, spacing_ratio_for,
 };

--- a/tests/pan_offset.rs
+++ b/tests/pan_offset.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use price_chart_wasm::app::{HISTORY_PRELOAD_THRESHOLD, should_fetch_history};
 
 #[test]

--- a/tests/pan_viewport.rs
+++ b/tests/pan_viewport.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use price_chart_wasm::app::visible_range_by_time;
 use price_chart_wasm::domain::chart::value_objects::Viewport;
 use price_chart_wasm::domain::market_data::{Candle, OHLCV, Price, Timestamp, Volume};

--- a/tests/performance_limit.rs
+++ b/tests/performance_limit.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use price_chart_wasm::domain::{
     chart::{Chart, ChartType},
     market_data::{Candle, OHLCV, Price, Timestamp, Volume},

--- a/tests/positioning_regression.rs
+++ b/tests/positioning_regression.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use price_chart_wasm::infrastructure::rendering::renderer::{
     EDGE_GAP, MAX_ELEMENT_WIDTH, MIN_ELEMENT_WIDTH, candle_x_position, spacing_ratio_for,
 };

--- a/tests/realtime_viewport.rs
+++ b/tests/realtime_viewport.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use price_chart_wasm::domain::chart::Chart;
 use price_chart_wasm::domain::chart::value_objects::{ChartType, Viewport};
 use price_chart_wasm::domain::market_data::{Candle, OHLCV, Price, Timestamp, Volume};

--- a/tests/reconnect.rs
+++ b/tests/reconnect.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use futures::future::select;
 use gloo_timers::future::sleep;
 use price_chart_wasm::domain::market_data::{Symbol, TimeInterval};

--- a/tests/rendering_sync.rs
+++ b/tests/rendering_sync.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use price_chart_wasm::domain::{
     chart::{Chart, value_objects::ChartType},
     market_data::{Candle, OHLCV, Price, Timestamp, Volume},

--- a/tests/series_expansion.rs
+++ b/tests/series_expansion.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use price_chart_wasm::app::visible_range;
 use price_chart_wasm::domain::chart::{Chart, value_objects::ChartType};
 use price_chart_wasm::domain::market_data::{Candle, OHLCV, Price, Timestamp, Volume};

--- a/tests/single_candle_width.rs
+++ b/tests/single_candle_width.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use price_chart_wasm::infrastructure::rendering::renderer::{
     MAX_ELEMENT_WIDTH, MIN_ELEMENT_WIDTH, spacing_ratio_for,
 };

--- a/tests/start_realtime.rs
+++ b/tests/start_realtime.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use price_chart_wasm::app::{visible_range, visible_range_by_time};
 use price_chart_wasm::domain::chart::{Chart, value_objects::ChartType};
 use price_chart_wasm::domain::market_data::{

--- a/tests/stream_abort_no_panic.rs
+++ b/tests/stream_abort_no_panic.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use gloo_timers::future::sleep;
 use leptos::*;
 use price_chart_wasm::app::{

--- a/tests/switch_symbol_abort.rs
+++ b/tests/switch_symbol_abort.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use futures::future::{AbortHandle, Abortable};
 use gloo_timers::future::sleep;
 use leptos::*;

--- a/tests/switch_symbol_loop.rs
+++ b/tests/switch_symbol_loop.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use futures::future::AbortHandle;
 use leptos::*;
 use price_chart_wasm::app::{abort_other_streams, current_symbol, stream_abort_handles};

--- a/tests/symbol_list.rs
+++ b/tests/symbol_list.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use price_chart_wasm::domain::market_data::value_objects::{Symbol, default_symbols};
 use wasm_bindgen_test::*;
 

--- a/tests/time_label_format.rs
+++ b/tests/time_label_format.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use js_sys::Date;
 use price_chart_wasm::time_utils::format_time_label;
 use wasm_bindgen::JsValue;

--- a/tests/time_scale_sync.rs
+++ b/tests/time_scale_sync.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use price_chart_wasm::app::{visible_range, visible_range_by_time};
 use price_chart_wasm::domain::chart::{Chart, value_objects::ChartType};
 use price_chart_wasm::domain::market_data::{

--- a/tests/tooltip_positioning.rs
+++ b/tests/tooltip_positioning.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use price_chart_wasm::infrastructure::rendering::renderer::{
     EDGE_GAP, MAX_ELEMENT_WIDTH, MIN_ELEMENT_WIDTH, candle_x_position, spacing_ratio_for,
 };

--- a/tests/view_state_zoom.rs
+++ b/tests/view_state_zoom.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use price_chart_wasm::view_state::ViewState;
 use quickcheck_macros::quickcheck;
 

--- a/tests/viewport.rs
+++ b/tests/viewport.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use price_chart_wasm::domain::chart::value_objects::Viewport;
 use wasm_bindgen_test::*;
 

--- a/tests/viewport_clamp.rs
+++ b/tests/viewport_clamp.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use price_chart_wasm::domain::chart::{Chart, value_objects::ChartType};
 use price_chart_wasm::domain::market_data::{Candle, OHLCV, Price, Timestamp, Volume};
 use wasm_bindgen_test::*;

--- a/tests/visibility_refresh.rs
+++ b/tests/visibility_refresh.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use price_chart_wasm::domain::{
     chart::{Chart, value_objects::ChartType},
     market_data::{Candle, OHLCV, Price, Timestamp, Volume},

--- a/tests/visible_len_zero.rs
+++ b/tests/visible_len_zero.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use price_chart_wasm::infrastructure::rendering::renderer::candle_x_position;
 use wasm_bindgen_test::*;
 

--- a/tests/visible_range.rs
+++ b/tests/visible_range.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use price_chart_wasm::app::visible_range;
 
 #[test]

--- a/tests/volume_candle_sync.rs
+++ b/tests/volume_candle_sync.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use price_chart_wasm::domain::market_data::{Candle, OHLCV, Price, Timestamp, Volume};
 use price_chart_wasm::infrastructure::rendering::renderer::{
     EDGE_GAP, MAX_ELEMENT_WIDTH, MIN_ELEMENT_WIDTH, SPACING_RATIO, candle_x_position,

--- a/tests/volume_vertices.rs
+++ b/tests/volume_vertices.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use price_chart_wasm::infrastructure::rendering::gpu_structures::CandleGeometry;
 use wasm_bindgen_test::*;
 

--- a/tests/vs_transform.rs
+++ b/tests/vs_transform.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use price_chart_wasm::infrastructure::rendering::gpu_structures::{CandleInstance, CandleVertex};
 use wasm_bindgen_test::*;
 

--- a/tests/websocket_parse.rs
+++ b/tests/websocket_parse.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use price_chart_wasm::domain::market_data::{Symbol, TimeInterval};
 use price_chart_wasm::infrastructure::websocket::binance_client::BinanceWebSocketClient;
 use wasm_bindgen_test::*;

--- a/tests/width_sync_test.rs
+++ b/tests/width_sync_test.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use price_chart_wasm::infrastructure::rendering::renderer::{
     EDGE_GAP, MIN_ELEMENT_WIDTH, candle_x_position, spacing_ratio_for,
 };

--- a/tests/zoom_centering.rs
+++ b/tests/zoom_centering.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use price_chart_wasm::domain::chart::value_objects::Viewport;
 use wasm_bindgen_test::*;
 

--- a/tests/zoom_preservation.rs
+++ b/tests/zoom_preservation.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use price_chart_wasm::domain::chart::{Chart, value_objects::ChartType};
 use price_chart_wasm::domain::market_data::{Candle, OHLCV, Price, Timestamp, Volume};
 use wasm_bindgen_test::*;

--- a/tests/zoom_price.rs
+++ b/tests/zoom_price.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 use price_chart_wasm::domain::chart::value_objects::Viewport;
 use wasm_bindgen_test::*;
 


### PR DESCRIPTION
## Summary
- gate tests with `logic-only` and `render` features
- run logic-only tests in Node and render tests in Chrome CI jobs
- document test profiles in `tests/README.md`

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches -- -D warnings`
- `cargo test` *(fails: could not execute wasm binaries)*
- `cargo test --features logic-only --target wasm32-unknown-unknown --no-run`
- `cargo test --features render --target wasm32-unknown-unknown --no-run`

------
https://chatgpt.com/codex/tasks/task_e_68a961a88e808332a81198d444f176cd