### PR TITLE
Ensure CCW orientation for indicator segments

### DIFF
--- a/src/infrastructure/rendering/gpu_structures.rs
+++ b/src/infrastructure/rendering/gpu_structures.rs
@@ -510,14 +510,14 @@ impl CandleGeometry {
 
             // Create a rectangle as two triangles without gaps
             let segment_vertices = [
-                // First triangle
+                // First triangle (CCW)
                 CandleVertex::indicator_vertex(x1 - perp_x, y1 - perp_y, indicator_type),
+                CandleVertex::indicator_vertex(x2 - perp_x, y2 - perp_y, indicator_type),
+                CandleVertex::indicator_vertex(x1 + perp_x, y1 + perp_y, indicator_type),
+                // Second triangle (CCW)
                 CandleVertex::indicator_vertex(x1 + perp_x, y1 + perp_y, indicator_type),
                 CandleVertex::indicator_vertex(x2 - perp_x, y2 - perp_y, indicator_type),
-                // Second triangle
-                CandleVertex::indicator_vertex(x1 + perp_x, y1 + perp_y, indicator_type),
                 CandleVertex::indicator_vertex(x2 + perp_x, y2 + perp_y, indicator_type),
-                CandleVertex::indicator_vertex(x2 - perp_x, y2 - perp_y, indicator_type),
             ];
 
             vertices.extend_from_slice(&segment_vertices);

--- a/tests/indicator_vertices.rs
+++ b/tests/indicator_vertices.rs
@@ -24,6 +24,22 @@ fn indicator_line_vertex_count() {
 }
 
 #[wasm_bindgen_test]
+fn indicator_line_segments_are_ccw() {
+    let points = [(-0.5, 0.0), (0.5, 0.0)];
+    let verts = CandleGeometry::create_indicator_line_vertices(&points, IndicatorType::SMA20, 0.1);
+
+    let orient_first = (verts[1].position_x - verts[0].position_x)
+        * (verts[2].position_y - verts[0].position_y)
+        - (verts[1].position_y - verts[0].position_y) * (verts[2].position_x - verts[0].position_x);
+    let orient_second = (verts[4].position_x - verts[3].position_x)
+        * (verts[5].position_y - verts[3].position_y)
+        - (verts[4].position_y - verts[3].position_y) * (verts[5].position_x - verts[3].position_x);
+
+    assert!(orient_first > 0.0);
+    assert!(orient_second > 0.0);
+}
+
+#[wasm_bindgen_test]
 fn indicator_line_color_types() {
     let pts = [(-1.0, 0.0), (1.0, 1.0)];
     let checks = [


### PR DESCRIPTION
## Summary
- reorder indicator line triangle vertices so every segment is emitted counter-clockwise `F:src/infrastructure/rendering/gpu_structures.rs#L513-L520`
- add a wasm-bindgen test asserting positive pseudo-cross products for a horizontal indicator segment `F:tests/indicator_vertices.rs#L27-L39`

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`
- `cargo test` *(fails: wasm-bindgen UI tests panic because DOM elements are missing in the headless runner)*


------
https://chatgpt.com/codex/tasks/task_e_68cb8a55ee3483329c732bf45094feee