### PR TITLE
Handle moving average updates on candle revisions

### DIFF
--- a/tests/moving_average_updates.rs
+++ b/tests/moving_average_updates.rs
@@ -1,0 +1,51 @@
+#![cfg(feature = "render")]
+
+use price_chart_wasm::domain::chart::Chart;
+use price_chart_wasm::domain::chart::value_objects::ChartType;
+use price_chart_wasm::domain::market_data::{
+    Candle, OHLCV, Price, TimeInterval, Timestamp, Volume, indicator_engine::MovingAverageEngine,
+};
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
+fn candle(ts: u64, close: f64) -> Candle {
+    Candle::new(
+        Timestamp::from(ts),
+        OHLCV::new(
+            Price::from(close),
+            Price::from(close),
+            Price::from(close),
+            Price::from(close),
+            Volume::from(1.0),
+        ),
+    )
+}
+
+#[wasm_bindgen_test]
+fn partial_realtime_updates_refresh_mas() {
+    let mut chart = Chart::new("test".into(), ChartType::Candlestick, 256);
+
+    for i in 0..19_u64 {
+        chart.add_realtime_candle(candle(i * 2_000, (i + 1) as f64));
+    }
+
+    let last_ts = 19 * 2_000;
+    chart.add_realtime_candle(candle(last_ts, 20.0));
+    chart.add_realtime_candle(candle(last_ts, 40.0));
+
+    let mut expected = MovingAverageEngine::new();
+    for close in 1..=19 {
+        expected.update_on_close(close as f64);
+    }
+    expected.update_on_close(40.0);
+
+    let base_engine = chart.ma_engines.get(&TimeInterval::TwoSeconds).expect("base engine");
+    assert_eq!(base_engine.data().sma_20.last(), expected.data().sma_20.last());
+    assert_eq!(base_engine.data().ema_12.last(), expected.data().ema_12.last());
+    assert_eq!(base_engine.data().ema_26.last(), expected.data().ema_26.last());
+
+    let minute_engine = chart.ma_engines.get(&TimeInterval::OneMinute).expect("minute engine");
+    assert_eq!(minute_engine.data().ema_12.last().map(|price| price.value()), Some(40.0));
+    assert_eq!(minute_engine.data().ema_26.last().map(|price| price.value()), Some(40.0));
+}


### PR DESCRIPTION
## Summary
- Added SMA/EMA replacement helpers so `MovingAverageEngine` can adjust window sums and last EMA when the latest close is revised in place.【F:src/domain/market_data/indicator_engine.rs#L83-L201】
- Taught `Chart::add_realtime_candle` and aggregate updates to detect timestamp-equal candles and invoke the replacement path, keeping indicators in sync during partial updates.【F:src/domain/chart/entities.rs#L100-L225】
- Added a wasm-bindgen integration test that feeds repeated real-time closes and checks that SMA/EMA settle on the final value for base and aggregated intervals.【F:tests/moving_average_updates.rs#L1-L50】

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --tests --benches --fix --allow-dirty -- -D warnings`
- `cargo test` *(fails: wasm-bindgen UI tests panic at `src/app.rs:1421` because DOM-dependent setup is unavailable in the harness)*
- `CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=wasm-bindgen-test-runner cargo test` *(fails with the same DOM-dependent wasm tests)*

------
https://chatgpt.com/codex/tasks/task_e_68cb93d1c11c833291d91f13e9989453